### PR TITLE
general improvements to several role pages, adds several placeholder and complete pages.

### DIFF
--- a/docs/Guides/General guides/Guide-to-Player-Species.md
+++ b/docs/Guides/General guides/Guide-to-Player-Species.md
@@ -1,0 +1,26 @@
+# Guide to Player Species
+During your time on station you may find yourself face to face (or face to mirror) with the not quite human. Be they aliens, mutated humans, or self aware constructs you're expected to try and coexist on this deathtrap
+Learning their quirks can be key to knowing how to keep them amicable in times of peace, and easy to put down in times of strife.
+
+##  <u>Roundstart Choices</u> 
+
+These are the races allowed to be chosen at round start. Because they are freely available, you should expect to deal with them nearly every round.
+
+### <u>Humans</u>
+
+
+
+### <u>Lizards</u>
+
+
+
+### <u>Moths</u>
+
+
+
+### <u>Felinids</u>
+
+
+
+##  <u>Exotics</u>
+

--- a/docs/Guides/General guides/Standard-Operating-Procedure.md
+++ b/docs/Guides/General guides/Standard-Operating-Procedure.md
@@ -14,6 +14,7 @@ Elevated alert level. There are reports or other proof available to indicate tha
 
 - Security may have weapons visible.
 - Crew members may be searched by security with probable cause.
+- the AI may bolt down high-risk areas.
 - Energy guns, laser guns and riot gear are allowed to be given out to security personnel if the HoS or Warden agree.
 
 ## <font color= "red">Code Red - Immediate Threat</font>.
@@ -22,12 +23,13 @@ Maximum alert level. There is an immediate threat to the station or severe damag
 
 - Security can raid departments and arrest any crew member deemed a threat to the station.
 - All station personnel that are not members of Command or Security must remain in their departments.
+- the AI may bolt down any threatened sectors as it sees fit.
 
 ## <font color= "#purple">Code Delta - Imminent Destruction</font>.
 
 The station's self destruct mechanism has been engaged due to overwhelming threat to the station. Martial Law is in effect.
 
-- All orders from Heads of Staff and Security must be followed, any disobedience is punishable.
+- All orders from Heads of Staff and Security must be followed, any disobedience is punishable by death.
 - All crew members are to evacuate immediately, if possible.
 
 

--- a/docs/Items/Engineering Items.md
+++ b/docs/Items/Engineering Items.md
@@ -1,0 +1,2 @@
+# Engineering Items
+Mega Wip

--- a/docs/Items/General Items.md
+++ b/docs/Items/General Items.md
@@ -1,0 +1,2 @@
+# General Items
+Mega Wip

--- a/docs/Items/High-Risk Items.md
+++ b/docs/Items/High-Risk Items.md
@@ -1,41 +1,43 @@
 # High Risk Items
 
-So you’re an antagonist, maybe a traitor who needs to seal the [nukedisk](Nuclear-Authentication-Disk.md); maybe you’re a wizard who needs to swipe the captain’s whip. This page will tell you were to find items you need for that sweet green text, or the people who may be using them. (Also it is a guide of good objectives if you are looking for an "adventure")
+So you’re an antagonist, maybe a traitor who needs to steal the [nuke disk](Nuclear-Authentication-Disk.md); maybe you’re a wizard who needs to swipe the captain’s whip. This page will tell you where to find items you need for that sweet green text and the people who may be using them.
 
-Here is a list of (at least the vast majority of) the most wanted items in the station:
+## The Nuke Disk
 
-## The nuke disc
+The [nuke disk](Nuclear-Authentication-Disk.md) is an item that spawns in the [captain's](Captain.md) office. It is used to authenticate the activation of the on-station self destruct nuke as well as the syndicate nuke brought by the nuclear operatives.
 
-The [nuke disk](Nuclear-Authentication-Disk.md) is an item that spawns in the captains office, that means it is usually in the hands (or pockets) of the [captain](Captain.md). It is extremely powerful, because as long as the nuke code is inputed in the nuke, it can blow up the entire station.
+With nuke disk pinpointers and a variety of antag roles specialized on taking this disk away, this is THE MOST risky item to have on your persona. People interested in this item would be:
 
-With countless nuke disk pinpointers and a variety of antag roles specialized on taking this disk away, this is THE MOST risky item to have on your persona. People interested in this item would be:
-
-  1) [Nuke Ops](Nuclear%20Operative.md). Not the most dangerous but the most consistent, and a force to be reckoned with. Their objective is to use this item to blow up the station. They are well armed and have a disk pinpointer.
-  2) [Wizards](Wizard.md). Very dangerous and consistent, very well armed with their spells and magic weapons they present a big threat to the station. They most of the time dont have a disk pinpointer, but they have teleportation so beware.
-  3) [Traitors](Traitor.md). By far the least dangerous and somewhat inconsistent. They may be assigned to steal the disk and leave the station, wich leaves them vulnerable to be killed while trying to leave.
-  4) [Death Squad](Death-Squad.md). By far the most dangerous, but very inconsistent, as they do only appear when the wrath of the admin is too bad. They are BY FAR the most well equiped people you will find, and ARE NOT to be taken slightly. Spacing the nuke disk in order to delay the death squad is actually a valid strategy at that point, and the best option is setting the escape shuttle to arrive in the least time possible and getting out ASAP. They have a disk pinpointer.
-  5) The station command. Of course, the [cap](Captain.md) is going to be on the lookout for the disk if its lost, so beware of him if you are antag.
+  1) [Nuke Ops](Nuclear%20Operative.md). The most consistent and a force to be reckoned with. Their objective is to use this item to blow up the station. They are well armed and have disk pinpointers.
+  2) [Wizards](Wizard.md). Very dangerous and consistent, very well armed with their spells and magic weapons, they present a big threat to the station. They most of the time don't have a disk pinpointer, but they have teleportation so beware.
+  3) [Traitors](Traitor.md). The least dangerous and somewhat inconsistent. They may be assigned to steal the disk and leave the station, which leaves them vulnerable to be killed while trying to leave.
+  4) [Death Squad](Death-Squad.md). *The most dangerous bar none,* but very inconsistent, as they only appear during admin events. They are BY FAR the most well equipped people you will find, and ARE NOT to be taken slightly. The best option is setting the escape shuttle to arrive in the least time possible and getting out ASAP. They have access to disk pinpointers.
+  5) The station command. Of course, the [Cap](Captain.md) is going to be on the lookout for the disk if its lost, so beware of him if you are an antag.
 
 ## The Justitia
 
-Big laser gun. Can be found in the [HoS](Head-of-Security.md)'s locker or in his person most of the time. It needs the proper keycard to be fired. Only wanted by [wizards](Wizard.md), [traitors](Traitor.md) and the [HoS](Head-of-Security.md) himself.
+Fancy laser pistol. Can be found in the [HoS](Head-of-Security.md)'s locker or on his person most of the time. It needs the proper keycard to be fired. Has 3 different fire modes; kill, disable, and stun. Wanted by [wizards](Wizard.md) and [traitors](Traitor.md).
 
 ## The Imperator
 
-The other big laser gun. Can be found in the [captain](Captain.md)'s locker or in his person most of the time. It also needs the proper keycard to be fired. Only wanted by [wizards](Wizard.md), [traitors](Traitor.md) and the [Captain](Captain.md) himself.
+The other fancy laser pistol. Can be found in the [Captain](Captain.md)'s locker or on his person most of the time. It also needs the proper keycard to be fired. Wanted by [wizards](Wizard.md) and [traitors](Traitor.md).
 
-## The Chain of command
+## The Chain of Command
 
-A whip made out of a chain. Can be found in the [captain](Captain.md)'s office, in his person or in some rare ocasions in the [mime](Mime.md) for some reason. It seems like the mime has a tendency to have the chain of command. It is wanted by [wizards](Wizard.md), [traitors](Traitor.md) and the [mime](Mime.md). The [captain](Captain.md) usually does not give a fuck about this item, and it is safer in his office.
+A symbolic chain kept in the [Captain](Captain.md)'s office, on his person or in some rare occasions with the [mime](Mime.md) for some reason. It is wanted by [wizards](Wizard.md), [traitors](Traitor.md), and the [mime](Mime.md). The [captain](Captain.md) usually does not care about this item, and it is left in his office.
 
-## Advanced Magboots
+## The Advanced Magboots
 
-Magnetic Boots related to the [chief engineer](Chief-Engineer.md). They work like every other magboots. They are wanted by [wizards](Wizard.md), [traitors](Traitor.md) and the engineering department in general.
+Magnetic Boots found in the [chief engineer's](Chief-Engineer.md) suit storage unit in their office. They work like every other pair of magboots but have no slowdown when turned on. They are wanted by [wizards](Wizard.md) and [traitors](Traitor.md).
 
 ## Plasma Sheets
 
-Very flamable material with the power to give light to the entire station. It is used to power the plasma generator in the engineering department that keeps the station running, by cargo to fulfill the station´s mission (that paper printed in command consoles that nobody cares about) and by science to make very neat equipment (well, sometimes). It is wanted by those departments, by the station command (they will confiscate plasma if its seen) and by [wizards](Wizard.md), [traitors](Traitor.md). It is the most demanded item in this list, but also the most common, since it can be mined by shaft miners and the crew in various locations.
+Very flammable material with unusual physical and chemical properties. It is used to power the plasma generator and radiation collectors in the engineering department, by cargo to fulfill the station's mission, and by science to make very neat equipment. It is wanted by [wizards](Wizard.md) and [traitors](Traitor.md). It is the most demanded item in this list, but also the most common, since it can be mined by shaft miners and the crew in various locations.
 
-## HoS's Trenchcoat
+## The Ablative Trenchcoat
 
-A trenchcoat. It has no major uses. Wanted by [wizards](Wizard.md) and [traitors](Traitor.md). Sometimes the [HoS](Head-of-Security.md) will actually give a fuck about it and have it on. Sometimes it will just be hanging in his office.
+An experimental trenchcoat that provides high resistance to energy and laser weapons. Kept in the Armory or in the Warden's locker. Wanted by [wizards](Wizard.md) and [traitors](Traitor.md).
+
+## The Hypospray
+
+An Advanced injection device. Kept in the CMO's Office. Wanted by [wizards](Wizard.md) and [traitors](Traitor.md).

--- a/docs/Items/Medical Items.md
+++ b/docs/Items/Medical Items.md
@@ -1,0 +1,2 @@
+# Medical Items
+Mega Wip

--- a/docs/Items/Science Items.md
+++ b/docs/Items/Science Items.md
@@ -1,0 +1,2 @@
+# Science Items
+Mega Wip

--- a/docs/Items/Security Items.md
+++ b/docs/Items/Security Items.md
@@ -1,0 +1,2 @@
+# Security Items
+Mega Wip

--- a/docs/Maps/Asteroid.md
+++ b/docs/Maps/Asteroid.md
@@ -1,6 +1,12 @@
 # Asteroid
-Asteroids are randomly located chunks of rock scattered floating around the station. There are 5 asteroids at round start. Each asteroid has a set layout, but randomly generated ore and somewhat randomly generated threats; mostly lots of [Xenomorphs.](Xenomorph.md) 
-
+Asteroids are randomly located chunks of rock scattered floating around the station. There are 9 asteroids at round start. Each asteroid has a set layout, but randomly generated ore and somewhat randomly generated threats; mostly lots of space carp, but occasionally [Xenomorphs.](Xenomorph.md) 
 
 These rocks are where [miners](Shaft-Miner.md) go to die.
 
+## Xenoartifacts
+
+Some Asteroids contain mysterious artifacts which possess unusual properties that can be either helpful or dangerous. The properties and appearance of the artifacts are randomized at round start. Artifacts can most easily tracked down by acquiring an Artifacts Detector, which are available at round start to scientists and the Curator, or can be purchased in the Mining Equipment Vendor. When used in hand, the detector will point out the relative coordinates of the nearest 3 artifacts.
+
+
+
+# Space Ruins

--- a/docs/Maps/Offical Station Maps/Boxstation.md
+++ b/docs/Maps/Offical Station Maps/Boxstation.md
@@ -1,0 +1,11 @@
+# Boxstation
+
+
+
+
+
+
+
+{% include 'html/rolesnavbar.md' %}
+[[Category:Maps]]
+

--- a/docs/Maps/Offical Station Maps/Squarestation.md
+++ b/docs/Maps/Offical Station Maps/Squarestation.md
@@ -1,0 +1,12 @@
+# Squarestation
+
+
+
+
+
+
+
+
+
+{% include 'html/rolesnavbar.md' %}
+[[Category:Maps]]

--- a/docs/Roles/Centcom roles/Centcom-Intern.md
+++ b/docs/Roles/Centcom roles/Centcom-Intern.md
@@ -1,0 +1,21 @@
+# Centcom Intern
+**Role type**: <font color= "#D4AF37">CentCom</font>. **Access**: <font color="green">Public</font>. **Difficulty**: <font color="Red">Extreme</font>.
+
+
+
+Note: The central command Intern is not a roundstart role and can currently only be accessed through admin events.
+
+
+## Who you are
+
+
+
+## How to do your job
+
+
+
+## Your gear
+
+
+
+{% include 'html/rolesnavbar.md' %}

--- a/docs/Roles/Centcom roles/Redshield-Officer.md
+++ b/docs/Roles/Centcom roles/Redshield-Officer.md
@@ -1,0 +1,27 @@
+# Redshield Officer
+**Role type**: <font color= "#D4AF37">CentCom</font>. **Access**: <font color="green">Security and command</font>. **Difficulty**: <font color="Red">Extreme</font>.
+
+
+
+
+## Who you are
+
+Welcome, Redshield. You have been given special training by Central Command, and been dispatched to serve as the personal bodyguard of everyone with access to Command Comms.
+
+
+Most of your time will be spent shadowing those you have been assigned to protect, making sure that they're alive and well, and keep an eye on a crew monitor to make sure they're still on sensors. Your job is to keep everyone in Command, as well as CentCom VIPs, alive.
+
+
+One very important detail of your job is that you are not [Security](Security-Officer.md). Do not let your Security access fool you. You should not be concerned with the goings-on at Security, nor should you be doing their job for them. You are not a Security Officer with elevated access and snazzy outfit. You are a bodyguard.
+
+
+
+## How to do your job
+
+---
+
+## Your gear
+
+The Redshield does not come with much special equipment, being outfitted mostly as a security officer with a stylish beret. Depending on the whims of your [supervisors](Admin.md), you may, rarely, receive additional gear.
+
+{% include 'html/rolesnavbar.md' %}

--- a/docs/Roles/Engineering roles/Engineer.md
+++ b/docs/Roles/Engineering roles/Engineer.md
@@ -4,25 +4,33 @@
 
 ## Overview
 
-Engineers are the repairmen and electricians of the station. If there's a hole isn the station providing one of the hallways or departments with a fresh view of space, it's the Engineer's job to fix it. If wires have been cut and half the station is out of power, it's the Engineer's job to fix it. As an Engineer, people expect you to know at least the basics of Construction, how the power system works and how to lay wires, etc. If you're ever confused on what to do, ask the [Chief Engineer](Chief-Engineer.md). They should give you advice, since they are your superior and it's their job to coordinate and assist engineers.
+Engineers are the repairmen and electricians of the station. If there's a hole in the station providing one of the hallways or departments with a fresh view of space, it's the Engineer's job to fix it. If wires have been cut and half the station is out of power, it's the Engineer's job to fix it. 
 
-At the bare minimum, you must know how to fix a hull breach and how to turn on the plasma generator. Learn how to do these as an asssistant to the [CE](Chief-Engineer.md) before you play as the only engineer on a low population server. Otherwise, you will have a really angry station on your back.
+As an Engineer, people expect you to know at least the basics of Construction, how the power system works and how to lay wires, etc. If you're ever confused on what to do, ask the [Chief Engineer](Chief-Engineer.md). They should give you advice, since they are your superior and it's their job to coordinate and assist engineers.
+
+At the bare minimum, you must know how to fix a hull breach and how to turn on the SMES. Learn how to do these as an assistant to the [CE](Chief-Engineer.md) before you play as the only engineer on a low population server. Otherwise, you will have a really angry station on your back.
 ### Bob the Builder
 
-this is just a very basic guide to how the construction system works. for a more in-depth guide, see [Construction](Construction.md)
+this is just a very basic guide to how the construction system works. for a more in-depth guide, see [Construction](Construction.md).
 
 In Unitystation, there are three materials you'll need to worry about: Metal Plates, Glass Sheets, and Metal Rods. There are some more, but these are the ones you'll most often be using. In order to craft/construct something, have a material selected in your hand, and either press Z or click on it in your hand. This will open a construction menu where you can select what item to build. Keep in mind some items will need more materials than others, for example a department battery will need 30 metal plates where as a girder will only need 2. 
 
 Once you've clicked on the item you want to build, wait for the bar above your head to fill up, and boom, you've built the item you want to build. Another note is that some items in the construction menu are intermediary constructions that must be finished with additional construction. For example, to build a wall requires you to construct a metal girder with 2 metal sheets, then finish the wall by clicking on the girder with 2 more sheets.
 
-Construction materials will go very fast, especially with a full engineering department. It will likely be necessary to order more materials from [Cargo](Quartermaster.md). If you have a [CE](Chief-Engineer.md), get in touch with them about what you need. Their status as a head will get things ordered and shipped faster. However, some [Shaft Miners](Shaft-Miner.md) [might](So-close-to-impossible-that-it-might-as-well-not-even-exist.md) randomly show up with a humongous shipment of construction materials, both basic and exotic, to let you go nuts with. Be thankful you don't have to share them with [Science](Roboticist.md) yet.
+Construction materials will go very fast, especially with a full engineering department. It will likely be necessary to order more materials from [Cargo](Quartermaster.md). If you have a [CE](Chief-Engineer.md), get in touch with them about what you need. Their status as a head will get things ordered and shipped faster. However, the [Shaft Miners](Shaft-Miner.md) [might](So-close-to-impossible-that-it-might-as-well-not-even-exist.md) randomly show up with a humongous shipment of construction materials, both basic and exotic, to let you go nuts with. Be thankful you don't have to share them with [Science](Roboticist.md) yet.
 
 
 ### Electricity
 
-An Engineer's job is also to keep the station powered. Often times, this is relatively simple: Keep the Plasma Generator stocked up on Plasma. On most stations, a crate of plasma will be available to you at round start, but the rest of engineering's stockpile is usually kept locked by shutters, unlockable only by the Chief Engineer. If someone complains about the lack of power despite the generator being fine, head to the area without power and make sure the wiring hasn't been cut.
+An Engineer's job is also to keep the station powered. At the beginning of the round, the station will have some power available in the SMESs, but it won't last long. It is your responsibility to **start the engine.** 
 
-The alternative to powering the station is the nuclear reactor. 'Do not fuck with the reactor until you have fully read [the guide to starting the reactor](Guide-to-the-nuclear-reactor.md) or it will fuck you back faster than you can even imagine.'
+Different maps will have different engines for you to work with. The plasma generator is pretty typical and easy to set up. On some maps it will have to be taken out of storage, but you wrench it onto the high voltage power line that feeds into the transformer and then you power it on. In most stations, a crate of plasma will be available to you at round start, but the rest of engineering's stockpile is usually kept locked by shutters, unlockable only by the Chief Engineer. If someone complains about the lack of power despite the generator being fine, head to the area without power and make sure the wiring hasn't been cut.
+
+The alternative choices to powering the station are much more complicated, and can go horribly wrong if you don't manage things closely. It is highly recommended to not mess with them without having read the guides or having a more experienced engineer walk you through the steps.
+
+ [click here for the guide to starting the Singularity and Tesla Engines](Guide to the Singularity and Tesla.md) 
+
+ [click here for the guide to starting the nuclear reactor](Guide-to-the-nuclear-reactor.md) 
 
 
 ### Tools
@@ -30,14 +38,15 @@ The alternative to powering the station is the nuclear reactor. 'Do not fuck wit
 
 Engineers get given a set of tools, both in their toolbelt and in toolboxes stored around the department. These include:
 
-*A Crowbar, for prying up floor tiles and prying open stuck doors and firelocks
-*A Screwdriver, for detaching windows, grilles, and dismantling unsecured girders
-*A Welder, for detaching the plates from walls
+*A Crowbar, for prying up floor tiles and prying open stuck doors and firelocks.
+*A Screwdriver, for detaching windows, grilles, and dismantling unsecured girders.
+*A Welder, for detaching the plates from walls and making repairs to damaged components.
 *A Wrench, for securing and unsecuring items (such as vents, girders, plasma tanks [when in a shuttle's fuel slot], etc.)
 *A Wirecutter, for cutting wires and destroying grilles
-*A Multitool, used for a variety of niche purposes. Mainly used for hacking.
-*Various types of Wires
+*A Multitool, used for connecting electrical machine to an APC and a variety of niche purposes. Also used for hacking.
+*High, medium, and low voltage wires.
 
 In addition, on most stations, each Engineer gets their own hardsuit. Cherish your birthright and never take it off. It will save your life.
 
 {% include 'html/rolesnavbar.md' %}
+

--- a/docs/Roles/Ghost roles/Ancient Engineer.md
+++ b/docs/Roles/Ghost roles/Ancient Engineer.md
@@ -1,8 +1,18 @@
 # Ancient Engineer
-'SCIENCE ROLES CURRENTLY CAN NOT DO ANYTHING RELATED TO THEIR JOB. KEEP THIS IN MIND WHEN PICKING VIROLOGIST, SCIENTIST, OR GENETICIST. PAGE WILL BE ADDED ONCE ROLE IS FUNCTIONAL.'
+**Job type:** <font color= "#74652c">Engineer</font>. **Access:** <font color="#74652c">The Ancient Station</font>, Maintenance. **Difficulty:** <font color="Yellow">Medium</font>
 
 
-Currently the laughing stock of the whole station
+## Overview
+
+The Ancient Engineer is an unusual role. Being a ghost role, it is only normally available to players that have died, and are spectating the round as a ghost. However, unlike most other ghost roles, it is *always* available.
+
+The Ancient Engineer is first and foremost meant to serve as an opportunity for players to practice the basics of engineering and basic combat while they wait for the next round to start. 
+
+When selected, you spawn as an Engineer who has been kept in suspended animation for an untold amount of time. You spawn with a decently robust but very heavy hardsuit and engineering equipment. Your station has fallen into disrepair in the extreme, with electrical and integrity issues everywhere. It is also inhabited by hostile creatures who will try to murder you on sight.
+
+If you are able to secure the station and repair enough of the systems damage, you will have basic suites to practice engineering, chemistry, atmospherics, and botany in relative peace. Your food, generator fuel, and building supplies are very limited, so you will have to develop a degree of self sufficiency if you want to stay. However, there are crates stashed away throughout the station that contain extra supplies if you are willing to search for them.
+
+The other choice is to repair the shuttle docked in the ship bay. To do so, you will have to find one of the two available shuttle console machine boards and use it to rebuild the piloting console in the shuttle. You will also have to secure plasma fuel from Atmospherics storage and dig away the asteroid rubble that has built up around the shuttle over the decades of inactivity. Once you have done so, you can leave the station and explore the local sector. Hint: the main station is located somewhere are coordinates 0,0, and it is totally permissible to return there so long as you don't metagame.
 
 {% include 'html/rolesnavbar.md' %}
 

--- a/docs/Roles/Ghost roles/Ancient Engineer.md
+++ b/docs/Roles/Ghost roles/Ancient Engineer.md
@@ -1,0 +1,8 @@
+# Ancient Engineer
+'SCIENCE ROLES CURRENTLY CAN NOT DO ANYTHING RELATED TO THEIR JOB. KEEP THIS IN MIND WHEN PICKING VIROLOGIST, SCIENTIST, OR GENETICIST. PAGE WILL BE ADDED ONCE ROLE IS FUNCTIONAL.'
+
+
+Currently the laughing stock of the whole station
+
+{% include 'html/rolesnavbar.md' %}
+

--- a/docs/Roles/Medical roles/Paramedic.md
+++ b/docs/Roles/Medical roles/Paramedic.md
@@ -1,32 +1,19 @@
 # Paramedic
 
-**Role type**: <font color= "#d673b2">Medical</font> . **Access**: <font color="#d673b2">Medbay</font>. **Difficulty**: <font color="Red">Extreme</font>.
+**Role type**: <font color= "#d673b2">Medical</font>. **Access**: <font color="#d673b2">Medbay</font>. **Difficulty**: <font color="Red">Extreme</font>.
 
 Note: for the guide to ordinary doctoring and first aid treatment, check [here](Medical-Doctor.md).
 
 ## Mr. Gurney
 
-As the paramedic, you have one main job, heal people that attempt to keel over outside medbay. failing that, you should keep them alive long enough to get to medbay for proper
-treatment. You are equal in rank to the geneticist, chemist, and other doctors, and need only take orders from the CMO and Captain. It is, however, often a good choice to prolong
-your own existence by obeying sec within reason and leaving an area when ordered to by its director or workers. You should at all times carry a medkit (or medkits, in extreme
-emergencies), a medical belt, and any manner of other healing gadgets you can feasibly store without pissing off the other doctors. It is also reccomended to wear you signature
-paramedic coat, as it distinguishes you from other doctors.
+You are essentially a rescue medic. You spend most of your time outside Medbay and therefore have reduced access. However you have increased access to the rest of the station. Your job is to rescue people, take them to Medbay, and leave them to be treated there, performing first aid as needed to make sure they make it there alive.
+
+You are equal in rank to all other medical staff, and need only take orders from the CMO and Captain. It is, however, often a good choice to prolong your own existence by obeying sec within reason and leaving an area when ordered to by its director or workers. You should at all times carry a first-aid kit, medical belt, roller bed, and any manner of other healing gadgets you can feasibly store without pissing off the other doctors.
 
 ## The practice
 
-When playing paramedic, there is little if any reason to stick around medbay, other doctors can handle that. your goal is to patrol the station looking for those that are close to
-or past the point where they become a corpse, heal them if possible (and allowed, dont want to heal some nukie by accident do we now?) or drag them to med. Checking maint on 
-occasion to locate any corpses stuffed within is reccomended, as is running into regions where combat or disaster is present or likely to occur. Maintaining a close relation and 
-communication with sec and engineering is reccomended, the prior will be the most likely to get into fights and need patching, while the latter is both the most common cause and 
-solution to structural failures.
+When playing paramedic, there is little if any reason to stick around Medbay. Your goal is to patrol the station looking for those that are in need of medical assistance, heal them if possible or drag them to Medical. Checking maintenance on occasion to locate any corpses stuffed within is recommended, as is running into regions where combat or disaster is present or likely to occur. Maintaining a close relation and communication with sec and engineering is recommended, the prior will be the most likely to get into fights and need patching, while the latter is both the most common cause and solution to structural failures.
 
-In emergency situations, you have, unsurprisingly, among the most important roles of the whole crew. Sec officers cant fight xenos if they are bleeding out on the floor, and 
-people cant run to evac if their legs have been blown apart. This is where you come in. Unlike the doctors, who will prioratize the dead for cloning the majority of the time, you
-should isntead keep your attention to the injured outside medical and leave the dead for others to haul around. Fixing people up at the front line of either a disaster or battle
-and sending them back off to fight it is typically far more efficient than hauling dead bodys back to medbay and returning. While you may think that the Paramedic would make a 
-good rescuer when it comes to explosives and breaches, they arent, and are instead just as likely to keel over responding to them as anyone else. let the engineers and atmos techs
-with their fancy hardsuits drag the corpses out for you instead and focus on healing those who barely made it out.
+In emergency situations, you have, unsurprisingly, among the most important roles of the whole crew. [Security Officers](Security Officer.md) can't fight xenos if they are bleeding out on the floor, and people cant run to evac if their legs have been blown apart. This is where you come in. Unlike the doctors, who will prioritize the dead for cloning the majority of the time, you should instead keep your attention to the injured outside medical and leave the dead for others to haul around. 
 
-If everything is fucked well past the point of no return or hope, you should hunker down like everyone else and slowly maneuver your way to a shuttle of any sort. if you meet 
-others, feel free to help them, but dont be a hero as youll more than likely die yourself, what with you being entirely unarmed and unarmoured. you cant heal others if you die,
-so try to save yourself first and others second.
+Fixing people up at the front line of either a disaster or battle and sending them back off to fight it is typically far more efficient than hauling dead bodies back to Medbay and returning. While you may think that the Paramedic would make a good rescuer when it comes to explosives and breaches, they aren't, and are instead just as likely to keel over responding to them as anyone else. let the engineers and atmos techs with their fancy hardsuits drag the corpses out for you instead and focus on healing those who barely made it out.

--- a/docs/Roles/Security roles/Head-of-Security.md
+++ b/docs/Roles/Security roles/Head-of-Security.md
@@ -1,37 +1,33 @@
 # Head of Security
 **Role type:** <font color= "#711e25">Security</font>. **Access:** <font color="#711e25">Security & cells</font>, <font color="#711e25">Brig</font>, <font color="#711e25">Armory</font>. **Difficulty:** <font color="Orange">Hard</font>.
 
-Note:The HoS is a difficult role to fill and you should probably be experienced in [combat](Combat.md) and with [security](Security.md) and [space law](Space-Law.md) before playing it.
+Note: The HoS is a *very* difficult role to play and you should probably be experienced in [combat](Combat.md) and with [security](Security.md),  [Standard Operating Procedure](Standard-Operating-Procedure.md), and [space law](Space-Law.md) before picking it.
 
-"alright, thats it, the chemist has lubed his last tile, blow up the chemlab boys."
+"alright, that's it, the chemist has lubed his last tile, blow up the chemlab boys."
 
 
 ### Who you are
 
-The HoS is, as the name implies, the Boss of all the [security officers](Security.md) on the station, as well as the [warden](Warden.md) and [detective](Detective.md). The only people that can order him around are the [Captain](Captain.md) and any [centcom representatives](Central-Command-Officer.md). He is second in line for succession should the [captain](Captain.md) die, after the [HoP](HoP.md). The HoS' job is to order around his underlings and check in on them from time to time to make sure they are performing well, as well as to manage securities emergency response should the time come.
+The Head of Security (HoS) is, as the name implies, the Boss of all the [security officers](Security.md) on the station, as well as the [warden](Warden.md) and [detective](Detective.md). The only people that can order him around are the [Captain](Captain.md) and any [centcom representatives](Central-Command-Officer.md). The HoS's job is to order around his underlings and check in on them from time to time to make sure they are performing well, as well as to manage securities emergency response should the time come.
 
 
 
 ### managing the day-to-day
 
-For a good portion of any round, and [possibly the entire round](So-close-to-impossible-that-it-might-as-well-not-even-exist.md), the station will be in a state of moderate peace where arming everyone to the teeth isn't needed. During these periods make sure that any [security officers](Security.md) stay on patrol and dont stick around the Brig when they arent needed to let them nip problems in the bud. The [|warden's](Warden.md) job is to manage guns and oversee timers, and as he doesnt need to hand any out during these periods hell likely be more than able to manage any unruly prisoners and keep track of release times. During these times of calm, you should check on patrolling [officers](Security.md) from time to time and build favor with the crew. Give laxer prison sentances for more minor crimes at this time, theres rarely reason to execute people yet.
+For a good portion of any round, and [possibly the entire round](So-close-to-impossible-that-it-might-as-well-not-even-exist.md), the station will be in a state of moderate peace where arming everyone to the teeth isn't needed. During these periods make sure that any [security officers](Security.md) stay on patrol and don't stick around the Brig when they aren't needed to let them nip problems in the bud. 
 
-
+The [Warden's](Warden.md) job is to manage guns and oversee timers, and as he doesn't need to hand any out during these periods hell likely be more than able to manage any unruly prisoners and keep track of release times. During these times of calm, you should check on patrolling [officers](Security.md) from time to time to make sure they aren't ruining everything and build favor with the crew.
 
 ### when shit hits the fan
 
-If things start burning and exploding, it may be a good time to order the [warden](Warden.md) to open armoury. Arm your [officers](Security.md) and order them on patrol. Should you trust the crew, you may give them guns, though you'd likely be better off giving them tasers and saving the guns for the heads. At these times the warden will likely be busy, and you will inevitably lose some officers. Be sure to help the [warden](Warden.md) manage the prison and direct [officers](Security.md) to recover their dead friends. This is the time to give harsher sentences, killing anyone who murders crew on the spot without trial should be the norm.
+If things start burning and exploding, it may be a good time to order the [Warden](Warden.md) to open the armory, but note that you cannot officially have your [Officers](Security.md) openly carrying weapons unless the alert level is at <font color= "blue">Code Blue</font> or higher (but it's rarely a problem because of how [SOP](Standard-Operating-Procedure.md) works). In a true emergency, should you trust the crew, you may give them guns, though you'd likely be better off giving them non-lethals and saving the guns for the heads. Be sure to help the [warden](Warden.md) manage the prison and direct [officers](Security.md) to recover their dead friends. 
 
-
-
-### Martial Law? Whats that?
-
-If somehow the station has gone to [|complete shit,with over half the crew dead and the station itself an atmosphereless wreck](Battle-royale.md), but a [good portion of officers have survived](So-close-to-impossible-that-it-might-as-well-not-even-exist.md), its time to enact martial law. At this point the Brig is likely non functional and the danger posed by antagonists is at its greatest.  You can likely get away with executing people for so much as not obeying orders from their superiors.
+If the alert level is ever elevated to <font color= "red">Code Red,</font> this is the time to give harsher sentences. You still need to get permission from the Captain to perform executions on the spot, but in the event that the chain of command has been disrupted and there is no clear authority, it's your call; at this point the Brig is likely non functional and the danger posed by antagonists is at its greatest.
 
 
 
 ### How to not end up with your head on a pike
 
-For any HoS, the crew can be just as much of a danger as [syndicate agents](Traitor.md) and [revolutionaries](Cargonia.md), and if you or your [officers](Security.md) piss them off enough, you may find your head paraded down the hall. The best way to prevent this is to work with the [lawyer](Lawyer.md), take headsets off your prisoners, and follow [space law](Space-Law.md). During downtime you can also try and build goodwill with the crew, arresting unwanted vandals and theives yourself will both show others security is doing their job and you are doing your part to help them.
+For any HoS, the crew can be just as much of a danger as [syndicate agents](Traitor.md) and [revolutionaries](Cargonia.md), and if you or your [officers](Security.md) piss them off enough, you may find your corpse paraded down the hall. The best way to prevent this is to work with the [lawyer](Lawyer.md), take headsets off your prisoners, and follow [space law](Space-Law.md). During downtime you can also try and build goodwill with the crew, arresting unwanted vandals and thieves yourself will both show others security is doing their job and you are doing your part to help them.
 
 {% include 'html/rolesnavbar.md' %}

--- a/docs/Roles/Service roles/Clown.md
+++ b/docs/Roles/Service roles/Clown.md
@@ -5,14 +5,15 @@
 ## Overview
 
 
-You are the Clown. The Funnyman. Mortal enemy of the [Mime](Mime.md). The one who's supposed to be making the crew members laugh, and act as stress relief. Instead, most see you as a threat due to most clown's tendencies to lube up the hallways and hide banana peels under doors. As such, don't be surprised if no one trusts you.
+You are the Clown. The Funnyman. Mortal enemy of the [Mime](Mime.md). The one who's supposed to be making the crew members laugh, and act as stress relief. Instead, most see you as a threat due to most clown's tendencies to lube up the hallways and hide banana peels under doors. As such, don't be surprised if no one trusts you. The best clowns mix actual clown stuff into their pranks. Having a funny gimmick and telling some jokes now and then can mean the difference between being murdered in a hallway and getting All Access.
 
 
 ### Just a prank bro HONK! HONK!
 
+Your job is simple. Make jokes, make people laugh, get beat up by the [people](Security.md) [in](Detective.md) [red](Warden.md) [suits](Nuclear-Emergency.md) for placing a banana peel. But, because of Clown's tendencies to mess the station up, very few people actually trust you with anything, and you are disliked by most; even more disliked than [the people in gray jumpsuits](Assistant.md). 
 
-Your job is simple. Make jokes, make people laugh, get beat up by the [people](Security.md) [in](Detective.md) [red](Warden.md) [suits](Nuclear-Emergency.md) for placing a banana peel. But, because of Clown's tendencies to mess the station up, very few people actually trust you with anything, and you are disliked by most; even more disliked than [the people in gray jumpsuits](Assistant.md). But, [there are some times where people actually trust you](So-close-to-impossible-that-it-might-as-well-not-even-exist.md), instead of just immediately voting to introduce you to the cold, airless vacuum of space. Value these moments, because it could be the only time your life isn't in danger 24/7.
+But, [there are some times where people actually trust you](So-close-to-impossible-that-it-might-as-well-not-even-exist.md), instead of just immediately voting to introduce you to the cold, airless vacuum of space. Value these moments, because it could be the only time your life isn't in danger 24/7.
 
-more to be added... eventually... probably... maybe not...
+Don't forget that your PDA is slippery, and can be used when you lose your banana peel.
 
 {% include 'html/rolesnavbar.md' %}

--- a/docs/Roles/Service roles/Cook.md
+++ b/docs/Roles/Service roles/Cook.md
@@ -1,7 +1,7 @@
 # Cook
 **Role type:** <font color= "#4e7331">Service</font>. **Access:** <font color="#4e7331">Kitchen & Butcher</font>, Maintenance. **Difficulty:** <font color="Green">Easy</font>''. ''Colloquial title: "Chef"
 
-Note: for the more detailed guide to food preperation, look [Here](Guide-to-Food-and-Drink.md).
+Note: for the more detailed guide to food preparation, look [Here](Guide-to-Food-and-Drink.md).
 
 
 
@@ -14,30 +14,9 @@ The Cook is one of the most simple roles on the station: Make food, serve it to 
 
 ### Dinner's ready
 
+Being a Cook is a relatively simple job. You have one duty: make sure the station doesn't starve. You have two ways of doing this: cooking raw steaks in the microwave, or [botany](Botanist.md) actually knowing how their job works. As for the meat steaks, you can either go to the Butcher's room (in Outpost station it's the room north of the kitchen, just head into the maintenance tunnels above you and the room will be on the other side), or by bugging [Medical](Medical-Doctor.md) for bodies once they've cloned said bodies. 
 
-Being a Cook is a relatively simple job. You have one duty: make sure the station doesn't starve. You have two ways of doing this: cooking raw steaks in the microwave, or [botany](Botanist.md) actually knowing how their job works. As for the meat steaks, you can either go to the Butcher's room (in outpoststation it's the room north of the kitchen, just head into the maintenance tunnels above you and the room will be on the other side), or by bugging [Medical](Medical-Doctor.md) for bodies once they've cloned said bodies. As for Botany, food preparation outside of just making steaks doesn't exist yet, so for now you can just ask them to hand you some crops so you can do your job without there being any meat on the station.
-
-To make a steak you must just take the meat, put it in a microwave, wait 10 seconds and serve. How does the microwave magically add a plate to the steak? Nobody knows, but we do know that those plates are pretty good for abusing the clown.
-
-![YOUTUBE](Jmj_ldi3www)?
-
-
-
-![YOUTUBE](Apv7pyqd4gu)?
-
-
-
-![YOUTUBE](Bfqrt7nq5a0)?
-
-
-
-![YOUTUBE](Wdg9emc9wqo)
-
-
-
-
-
-
+To make a steak you must take the meat, put it in a microwave, wait 10 seconds and serve. How does the microwave magically add a plate to the steak? Nobody knows, but we do know that those plates are pretty good for abusing the clown.
 
 
 

--- a/docs/Roles/Service roles/Janitor.md
+++ b/docs/Roles/Service roles/Janitor.md
@@ -4,51 +4,53 @@
 
 ## Overview
 
+Being a Janitor is a thankless job, but an important one. Not only is it simple, it's one of the two main jobs keeping the station from turning into a shit show, the other being [Security](Security.md). The more the station looks like an animal pen, the more the crew members [will act like it is one](Battle-royale.md). It is more fun than it sounds.
 
-Being a Janitor is a thankless job, but an important one. Not only is it simple, it's one of the two main jobs keeping the station from turning into a shit show, the other being [Security](Security.md). The more the station looks like an animal pen, the more the crew members [will act like it is one](Battle-royale.md).
+Keep the floors clean. Pick up trash.  Change broken lightbulbs. Mop up messes. Point at your wet floor sign when someone inevitably slips.
 
-
-
-
-### Floor's wet
-
-
-The Janitor's job is pretty simple. Grab either a mop and a bucket, or a bottle of cleaner, and head out to clean the station. Even if cleaning with a spray bottle is way more efficient than cleaning with a mop, here we show you both methods.
-
-
+This is the best role to pick as a new player.
 
 ## Equipment
 
 The Janitor's gear is highly specialized to cleaning messes:
 
-*First is the galoshes. They prevent you from slipping on wet floors (even space lubed floors, but do not protect you from banana peels or bars of soap).
-*Next is the janibelt. The janibelt is great because it starts with a mop, flashlight (equip to a pocket so it will shine at all times), a wet floor sign, and '4 space cleaner bottles.'
-*The mop-and-bucket combo is your main tool when the space cleaner runs out. The mop holds 25 units of fluid and consumes 5 units per use. You can clean multiple adjacent tiles at the same time. It can be refilled by dunking it in a bucket filled with water. Buckets hold 70 units of fluid and can be refilled at water tanks.
+- First is the galoshes. They prevent you from slipping on wet floors (even space lubed floors, but do not protect you from banana peels or bars of soap).
+- Next is the janibelt. The janibelt is great because it starts with a mop, flashlight (equip to a pocket so it will shine at all times), a wet floor sign, and '4 space cleaner bottles.'
 
-* Wet floor signs. Place these around where you've recently mopped or otherwise you will be lynched shortly by an angry mob.
 * The almightly space cleaner bottle. Space Cleaner is great because it does not leave a wet floor, so you can fire and forget. Not only that, but the bottle has a 3 tile range, allowing you to fire over counters and tables. Each bottle holds 100 space cleaner to begin with and consumes 6 per shot, so you get 17 per bottle. Once a bottle is empty, it can be refilled with water, but if there's a [Chemist](Chemist.md), they can [manufacture more space cleaner](Chemistry.md) for you.
-* Last is the trash bag. You can use a wielded trash bag to pick up trash on the floor, such as snack wrappers, dirty plates, and [evidence](Traitor.md). Trash bags hold 15 assorted items. In the janitorial closet, there's a trash bin and green dumpster crate. The trash bin currently does not work. To use the the dumpster crate, empty the trash bag by clicking on it while you are in front of the dumpster crate, then open the crate, drag it over the pile of trash, and close it.
+* The less mighty, but still useful in a pinch bar of soap. Soap does not leave a wet floor either, and it has a lot more uses before running out than the space cleaner, but it is a lot slower to use.
+* The mop-and-bucket combo is your main tool when the space cleaner runs out. The mop holds 25 units of fluid and consumes 5 units per use. You can clean multiple adjacent tiles at the same time. It can be refilled by dunking it in a bucket filled with water. Buckets hold 70 units of fluid and can be refilled at water tanks.
+* Wet floor signs. Place these around where you've recently mopped or otherwise you will be lynched shortly by an angry mob.
+* Last is the trash bag. You can use a wielded trash bag to pick up trash on the floor, such as snack wrappers, dirty plates, and [evidence](Traitor.md). Trash bags hold 15 assorted items.
 
 
 
-# Cleaning with a mop and bucket
+### Cleaning with a mop and bucket:
 
-1. Grab a mop and a bucket from one of the lockers inside the janitorial closet
+1. Grab a mop and a bucket from one of the lockers inside the janitorial closet.
 2. Have the bucket selected and click on the water tank inside your closet. Do this until it says the bucket is full.
-3. Head to the place that needs cleaning
-4. Put down wet floor signs. this means that you won't get in trouble if someone slips on the wet floor
-5. Click on the bucket with your mop
-6. Click on the spill with the mop equipped
-7. Wait for the bar to fill up, and you've successfully cleaned,remember to collect the wet floor sign in a minute or two once the floor has dried.
+4. Put down wet floor signs. this means that you won't get in trouble if someone slips on the wet floor.
+5. Click on the bucket with your mop.
+6. Click on the spill with the mop equipped.
+7. Wait for the bar to fill up, and you have successfully cleaned. Remember to collect the wet floor sign in a minute or two once the floor has dried.
 
 
 
-## Cleaning with the cleaner spray bottle
+### Cleaning with the cleaner spray bottle:
 
-1. Grab a bottle of cleaner, either from the janitorial lockers or from your belt
-2. Head to the place that needs cleaning
-3. Click on the tile that needs cleaning. The spray bottle has a 3-tile range
-4. You've successfully cleaned, <u>without leaving a wet floor behind</u>
+1. Grab a bottle of cleaner, either from the janitorial lockers or from your belt.
+2. Click on the tile that needs cleaning. The spray bottle has a 3-tile range.
+4. You have successfully cleaned, <u>without leaving a wet floor behind.</u>
+
+
+
+### Cleaning with a bar of soap:
+
+1. Grab a bar of soap, either from the janitorial vendor or from your belt.
+2. Click on the tile that needs cleaning.
+3. Wait for the bar to fill up and you have successfully cleaned <u>without leaving a wet floor behind</u>.
+
+
 
 Keep in mind that, while the bottle is faster and doesn't make the floor wet, there's a limited amount of cleaner in the bottle, and you need a [competent](So-close-to-impossible-that-it-might-as-well-not-even-exist.md) [Chemist](Chemist.md) in order to get more.
 


### PR DESCRIPTION

This PR:

- adds a boxstation page.
- adds a square station page.
- adds a centcom intern page.
- adds a security items page.
- adds a medical items page.
- adds a general items page.
- adds an engineering items page.
- adds a science items page.
- adds a placeholder page for player species.
- adds a redshield page.
- fixes some wording in the SOP page and adds the references to the AI now that it is a playable role.
- fixes really weird formatting in the Paramedic page and also trimmed it for length.
- fixed many typos, added some footnotes relating to SOP, and cut some of the indulgent prose of the HoS's page.
- edited the formatting of the Clown page.
- edited the High Risk Items page so it's less opinionated and stays to the point. Also added the hypospray to the list and corrected the ambiguous information on the ablative trenchcoat.
- updated a lot of the now irrelevant information in the Engineer page so that it is more relevant to modern Unitystation.
- closes #58 
- closes #61
- closes #62 
- closes #63
- closes #65 
- makes progress on #22 