### PR TITLE
Syndicate pages rewrite

### DIFF
--- a/docs/Items/Syndicate Items.md
+++ b/docs/Items/Syndicate Items.md
@@ -1,41 +1,102 @@
 # Syndicate Items
 
-This is a comprehensive list of all items that traitors and Syndicate Operatives can purchase through their Syndicate uplink hidden on their PDAs. Shortly after round spawn, operatives and traitors will receive notifications telling them a code phrase to input into their PDAs in the ringtone configuration under settings. Both Traitors and Operatives start with 20 Telecrystals (TC) to spend on specialist equipment to complete their objectives. At the moment, both get the same list of choices.
+This is a comprehensive list of all items that [Traitors](Traitor.md) and [Nuclear Operatives](Nuclear-Operative.md) can purchase through their Syndicate uplink hidden on their PDAs. Shortly after round spawn, operatives and traitors will receive notifications telling them a code phrase to input into their PDAs in the ringtone configuration under settings. Traitors start with 20 Telecrystals (TC) while operatives start with 25 TC to spend on specialist equipment to complete their objectives.
 
-| Category/Name | TC cost | Description |
+#### Traitor and Operative items:
+
+| Category/Name | Description | TC cost |
 | - | - | - |
-| **Conspicuous Weapons** |  | Obvious and hard to hide weapons. |
-|  Makarov Pistol | 7 | A small, easily concealable 9mm handgun. Has a threaded barrel for suppressors. | 
-|  Energy Sword  | 8 | When turned off, can be hid in many regions, when on, is a very distinct, loud, and deadly light-saber esque blade |
-|  Lucifer .357  | 12 | very loud and very powerful revolver, comparable to the cent officers own mateba. |
-|  Reverse Revolver | 8 | Revolver that shoots anyone that tries to fire it. | 
-|  **Ammunition** |  | Ammo for weapons |
-|  9mm pistol magazine  | 1 | 9mm ammo, used by the makarov. |
-|  9mm pistol magazine AP | 2 | 9mm ammo, penetrates armor. |
-|  9mm pistol magazine incendiary | 2 | 9mm ammo, lights people on fire. |
-|  .357 speedloader  | 4 | .357 ammo, used by the lucifer. |
-|  **Explosives** |  | Explosives, used for AOE damage or destruction of important objects. |
-|  Syndicate Minibomb  | 6 | Larger blast than a grenade, but smaller cost and blast than a full sized bomb. throwable. |
-|  C4  | 1 | Bomb that can put holes in walls. |
-|  X4  | 4 | C4 but more explosive | 
-|  Pizza Bomb | 10 | A bomb concealed in a pizza box | 
-|  **Stealthy Weapons** |  | Easily concealed and hard to trace weapons. |
-|  Energy Dagger | 2 | A smaller and weaker esword disguised as a pen, can be placed anywhere you can fit a pen. |
-|  Miniature Energy Crossbow | 10 | An (expensive) self charging and easily hideable pocket crossbow that stuns and poisions those it hits. basically a self charging concealable tazer. |
-|  Syndicate Holster | 1 | A holster for storing all the guns you buy. |
-|  Suppressor | 3 | Reduces the volume of some guns. | 
-|  **Suits** |  | Various suits, typically of the spaceworthy variety. |
-|  Syndicate Spacesuit | 4 | A SOFTSUIT that can be used similarly to other softsuits on the station. |
-|  Syndicate Hardsuit | 8 | The same armoured blood-red hardsuit used by nuclear operatives |
-|  **Misc Gadgets** |  | Gadgets that dont fit in with others |
-|  Chest Rig | 1 | Acts as a belt that can store guns, ammo, grenades, and all manner of other devices. |
-|  Cryptographic Sequencer | 6 | Causes doors to open, and certain other machinery to malfunction. | 
-|  Surgical Equipment Bundle | 3 | Equipment for doing surgery | 
-|  Full Syndicate Toolbox | 1 | A toolbox full of tools, but eviler. |
-|  Syndicate Soap | 1 | Soap, but red, menacing. good for cleaning up any blood from your assassinations. |
-|  **Pointless Badassery** |  | Useless, or with a very niche or RP oriented use. |
-|  Syndicate Balloon | 20 | A baloon to show everyone you are with the syndicate, great for getting yourself shot. |
-|  Briefcase Full of Cash | 1 | A Briefcase full of cash, need I say more? |
-|  Syndicate Smokes | 2 | A pack of syndicate smokes, operate in style! |
-|  **Bundles** |  |  |
-|  Raw Telecrystals | 1,5,10,20 | The currency for transactions made with the syndicate. Add them to a pda by clicking on it with them in hand. | 
+| **<font color="red">CONSPICUOUS WEAPONS</font>** | Obvious and hard to hide weapons. |  |
+|  Makarov Pistol | A small, easily concealable 9mm handgun. It deals 20 damage a shot and has a threaded barrel for suppressors. | 7TC |
+|  Energy Sword  | When turned off, can be hid in many regions, when on, is a very distinct, loud, and deadly light-saber esque blade. Deals high damage and can inflict body traumas. | 8TC |
+|  Lucifer .357  | very loud and very powerful revolver, comparable to the cent officers own mateba. deals 50 damage a shot. | 12TC |
+|  Reverse Revolver | Revolver that shoots anyone that tries to fire it, with one exception. | 8TC |
+| **<font color="red">AMMUNITION</font>** | Ammo for weapons |  |
+|  9mm pistol magazine  | 9mm makarov ammo, currently deals 20 damage a shot. | 1TC |
+|  9mm pistol magazine AP | 9mm makarov ammo, negates 50% of armor on hit. | 2TC |
+|  9mm pistol magazine incendiary | 9mm makarov ammo, deals half damage (10) but adds two firestacks to hit targets, giving a net gain of damage | 2TC |
+|  .357 speedloader  | .357 ammo, used by the lucifer. | 4TC |
+| <font color="red">**EXPLOSIVES**</font>            | Explosives, used for AOE damage or destruction of important objects. |  |
+|  Syndicate Minibomb  | stronger blast than a grenade, but hits a smaller total area. The detonation time after being activated is 5 seconds. | 6TC |
+|  C4  | A bomb that can be attached to walls, objects, and people. It can be configured to detonate on a timer (minimum time 10 seconds), or can be paired with a remote signaller to be remotely triggered. To pair it, simply click the remote signaller on the C4 brick and they are paired. | 1TC |
+|  X4  | C4 but more explosive. | 4TC |
+|  Pizza Bomb | A bomb concealed in a pizza box. | 10TC |
+| <font color="red">**STEALTHY WEAPONS**</font> | Easily concealed and hard to trace weapons. |  |
+|  Energy Dagger | A smaller and weaker esword disguised as a pen, can be placed anywhere you can fit a pen, like your PDA. | 2TC |
+|  Miniature Energy Crossbow | An (expensive) self charging and easily hideable pocket crossbow that stuns and poisons those it hits. basically a self charging concealable tazer. When fired, it does not leave a message in the chat that would give away your identity | 10TC |
+|  Syndicate Holster | A holster for storing all the guns you buy. Cannot currently be disguised, so it's not a very effective stealth tool at the moment. | 1TC |
+|  Suppressor | Reduces the volume of guns with threaded barrels and it does not leave chat messages saying who fired it. Current weapons that can be silenced are Makarovs and Stalker SMGs. | 3TC |
+| <font color="red">**SUITS**</font> | Various suits, typically of the spaceworthy variety. |  |
+|  Syndicate Spacesuit | A spacesuit that can be used similarly to other softsuits on the station. Despite being a softsuit, it is actually very protective, providing better stats than standard security officer armor. while it's main utility is for Traitors, don't forget that as a nuclear operative, this is a good option if you plan to sneak aboard the station and adopt a disguise as it is small enough to fit inside a backpack, allowing you to keep it for when you need to go loud or escape the station. | 4TC |
+|  Syndicate Hardsuit | The same armoured blood-red hardsuit used by nuclear operatives. Very distinct looking, very robust. | 8TC |
+| <font color="red">**MISC. GADGETS**</font> | Gadgets that don't fit in with others |  |
+|  Chest Rig | Acts as an 8 slot belt that can store guns, ammo, grenades, and all manner of other devices. Very cheap, very flexible storage, but also can't be hidden when worn. | 1TC |
+|  Cryptographic Sequencer | Otherwise known as the Emag. It causes doors to open, and certain other machinery to malfunction. Generally, the effects of the Emag are permanent unless someone repairs the affected machines; For example, doors will stay permanently open until repaired. The effects of the Emag are powerful, but it does mean that you leave an obvious trail to follow if you are being pursued. The Emag has 5 regenerating charges, and you can see roughly how many you have left on the card's sprite. It regenerates one charge after 30 seconds. | 6TC |
+|  Surgical Equipment Bundle | Comes with all the tools for surgery in a conspicuous, red and black duffel bag. | 3TC |
+|  Full Syndicate Toolbox | A mechanical toolbox full of tools, but eviler. Small serrations on the exterior of the toolbox also give it slightly increased melee damage. | 1TC |
+|  Syndicate Soap | Soap, but red, menacing. good for cleaning up any blood from your assassinations. | 1TC |
+| <font color="red">**(POINTLESS) BADASSERY**</font> | Useless fun, or with very niche or RP oriented uses. |  |
+|  Syndicate Balloon | A baloon to show everyone you are with the syndicate, great for getting yourself shot. | 20TC |
+|  Briefcase Full of Cash | A Briefcase full of cash, need I say more? | 1TC |
+|  Syndicate Smokes | A pack of syndicate smokes, operate in style! | 2TC |
+| <font color="red">**BUNDLES**</font> |  |  |
+|  Raw Telecrystals | The currency for transactions made with the syndicate. Add them to a PDA by clicking on it with them in hand. If you kill another traitor, check to see if their uplink is still unlocked on their PDA and take their telecrystals for yourself. | 1, 5, 10, or 20 TC |
+
+#### Operative Exclusive Items:
+
+Some items are only available to [Nuclear Operatives.](Nuclear-Operative.md) 
+
+| Category/Name                                    | Description                                                  | TC cost |
+| ------------------------------------------------ | ------------------------------------------------------------ | ------- |
+| **<font color="red">CONSPICUOUS WEAPONS</font>** | Obvious and hard to hide weapons.                            |         |
+| Stalker SMG                                      | A .45 cal SMG. Hits pretty hard                              | 10TC    |
+| Bulldozer shotgun                                | A drum-fed shotgun with a decent rate of fire. It accepts many different ammunition types, but the standard buckshot load is perhaps the deadliest one available to you. | 8TC     |
+| M90-gl carbine                                   | A strange 5.56 carbine with a high rate of fire and a currently non-functional under-barrel grenade launcher. Unremarkable without that grenade launcher, unfortunately, save for a very peculiar optional ammo type; 5.56 Phasic ammo. This ammo currently has some of the high armor penetration of any weapon in the game at 70%. Sadly, you can't get it with the carbine without declaring war or getting a fellow operative to donate 1TC to you. | 18TC    |
+| Buzzsaw LMG                                      | High capacity pain. This LMG fires fast, hits like a truck at 40 damage a bullet, and holds 50 rounds per magazine, making it one of the nastiest weapons available to you, especially if you invest in some of the alternate ammo types. | 18TC    |
+| Migraine .50 cal sniper rifle                    | A slow firing sniper rifle. You might think it strange to bring a sniper with you on a space station assault, but it has a few qualities that are quite valuable. First, it's standard ammunition deals 70 damage a shot and is inherently armor piercing, reducing armor by 50%. Second, it has a very high bullet velocity, making it hard to dodge. Third, it stuns targets for a brief moment. All of these qualities makes it a very effective ambush weapon. | 16TC    |
+| Toy LMG                                          | A toy buzzsaw that fires donksoft darts                      | 10TC    |
+| Toy SMG                                          | A toy stalker that fires donksoft darts                      | 5TC     |
+| Surplus Rifle                                    | A cheap piece of trash that isn't particularly effective, but for the TC spent, It provides some value. Your free stalker is *signficantly* more effective and it's free, though, so don't buy this unless you're looking to meme around. | 2TC     |
+| Stechkin APS machine Pistol                      | An automatic 9mm pistol. Similar overall effectiveness to the Makarov, but definitely more fun to use. | 10TC    |
+| 84mm Rocket Launcher                             | A reloadable rocket launcher preloaded with an 84mm HE rocket grenade. With a very large blast radius, a potent weapon versus crowds. the alternate HEDP rocket also has utility for  taking out heavily armored targets. | 8TC     |
+| Biohazardous chemical Sprayer                    | A currently semi-functional tool. Chemicals are in an awkward state, balance wise, so this item isn't recommended for use just yet. | 20TC    |
+| **<font color="red">AMMUNITION</font>**          | Ammo for Operative exclusive weapons                         |         |
+| 12g buckshot drum                                | Powerful, and the spread makes it hard to dodge.             | 2TC     |
+| 12g Dragons Breath drum                          | the *fun* option. fires 4 low-damage flaming projectiles. A great option for sowing panic. While you are unlikely to drop people with dragon's breath, you will definitely distract them, and likely force a retreat so they can put themselves out. Repeatedly shooting people with dragon's breath isn't a very effective use of the ammo as a single shell will apply 4 firestacks to them, and characters can only receive 5 firestacks at a given time. Since they can't put themselves out, a single shell will eventually burn a critted player to death if they don't have any fire protection, as the damage potential is over 100. | 2TC     |
+| 12g slug drum                                    | Fires a single slug that deals slightly less total damage than buckshot, but has 20% armor penetration and a higher projectile velocity, so if you are facing armored targets or are fighting over distance, consider picking this. | 3TC     |
+| .45 Magazine                                     | An extra magazine for the stalker SMG. Grab a few of these if you plan to stick with it. | 3TC     |
+| .45 Magazine Incendiary                          | Like other incendiary ammunition, this magazine deals half normal damage in exchange for igniting the target on fire. The stalker doesn't have a lot of synergy with incendiary ammunition, but it isn't a strictly bad purchase either, and it's cheap. | 4TC     |
+| .45 Magazine AP                                  | The stalker *does* have a lot of synergy with AP ammunition. If you know you are going to deal with a station prepared for your arrival or if you expect to encounter [Unusually](Redshield-Officer.md) [Tough](Emergency-Response-Team.md) [Resistance,](Death-Squad.md) since you get the stalker for free, this is a very cost effective way to get 50% armor penetration in an automatic package. | 5TC     |
+| 7.12 Box Magazine                                | More lead for the buzzsaw. Useful if the station is well populated or if you plan to use the buzzsaw as a literal saw to cut through windows and walls. | 6TC     |
+| 7.12 AP Box Magazine                             | Expensive, but if you are going against a full squad of [the best and baddest,](Death-Squad.md) accept no substitutes. | 9TC     |
+| 7.12 Incendiary Box Magazine                     | This paired with the Elite Syndicate Hardsuit is a contender for one of the most cancerous weapon-ammo-armor combos in the game. The buzzsaw deals so much damage per shot that the half-damage penalty for incendiary ammo isn't as significant as with other weapons, and lighting people on fire creates a significant problem for them to deal with while they fight you. | 6TC     |
+| .50 Sniper Magazine                              | With the low bullet count per magazine, you will probably have to buy a few of these (or better yet, buy the sniper bundle). Don't forget that this has 50% armor penetration as standard. | 4TC     |
+| .50 Penetrator Sniper Magazine                   | Doesn't currently go through targets like it's supposed to, but it does have somewhat better AP qualities over the standard magazine. | 5TC     |
+| 5.56 Magazine                                    | Nothing remarkable when compared to the stock stalker you get. If you are going for the carbine, then you want to look at the variant below. | 4TC     |
+| 5.56 Magazine Phasic                             | the cost is high, but so it the armor penetration. At 70% armor pen, this ammo destroys armored targets. It also has unusual projectile properties that can be advantageous. | 8TC     |
+| 40mm Grenade Rounds Box                          | without access to a grenade launcher, pass on this for now.  | 6TC     |
+| 84mm HE Rocket                                   | a high damage, wide blast area rocket. Use versus crowds. Also ensure that you have a space suit on because it will definitely punch a hole through the station. | 4TC     |
+| 84mm HEDP Rocket                                 | Doesn't have a very good use case (yet!). It does have high AP effects on the rocket's impact point, but because most of its damage is bomb damage, it's not even very good against centcom forces. | 6TC     |
+| 9mm stechkin Pistol Magazine                     | More ammo for the fancy sidearm.                             | 2TC     |
+| Riot Dart Box                                    | ammo for the dart guns.                                      | 2TC     |
+| <font color="red">**EXPLOSIVES**</font>          | Operative exclusive explosive items, used for AOE damage or destruction of important objects. |         |
+| Grenadier's Belt                                 | Very expensive, but if you are planning to buy a lot of grenades, this belt provides good savings. Comes with 2 minibombs, 6 grenades, 2 EMP grenades, a multitool, and an evil screwdriver. | 24TC    |
+| EMP grenade box                                  | A box full of 7 EMP grenades. If you want to cause chaos on the station without blowing holes in it, this kit is a good option. | 10TC    |
+| <font color="red">**SUITS**</font>               | Various suits, typically of the spaceworthy variety.         |         |
+| Blood-Red Magboots                               | For when you don't like the pair you start with for some reason. | 2TC     |
+| Elite Syndicate Hardsuit                         | an upgrade over your standard blood red hardsuit, this suit's utility isn't derived from extra protection from laser and bullets (it's a bit better than the standard suit, but actually has slightly weaker laser protection). Instead, you get this for the enhanced protection to environmental damages, such as bomb, fire, and acid damage. This is a great choice if you are at risk of damaging yourself with your own AOE weaponry. | 8TC     |
+| <font color="red">**MISC. GADGETS**</font>       | Gadgets that dont fit in with others                         |         |
+| Jaws of Life                                     | A handy power tool that can act as both a crowbar and wirecutters. It's main utility is that while in crowbar mode, it can force open *powered* airlocks, allowing you to force through any doors in your way. Do note that it's a bit loud when it does so, though, and it can't force open bolted doors, so a watchful [AI](Station-AI.md) can stall your progress. | 4TC     |
+| Syndicate Reinforcement                          | This option buys you a small transponder that when activated opens a ghost role that lets one dead player spawn as an extra Nuclear Operative. They start with all the stock equipment, but *no TC of their own,* so you've got to share with them to get them equipped. That, combined with the price of this option means this item is really only viable if you've declared war on the station for extra TC. | 25TC    |
+| <font color="red">**BUNDLES**</font>             | Think of the savings!                                        |         |
+| Bioterror bundle                                 | Currently not worth getting as chemistry is underdeveloped. 12 TC saved. | 30TC    |
+| Bulldozer bundle                                 | Comes with a Bulldozer shotgun, a 12g *stun* slug drum and buckshot drum. Stun slugs are a useful way to get stuns if you need to take someone alive for one reason or another. Saves you 3TC | 13TC    |
+| Stalker bundle                                   | A duffel bag that comes with a stalker with a supressor and two extra magazines. | 14TC    |
+| Sniper bundle                                    | A briefcase that comes with a Migraine, two spare magazinrs, and a worn out suit and tie. Saves you 6TC | 20TC    |
+| Spetznas Pyro Bundle                             | Currently not worth getting as it doesn't come with all items it is supposed to. | 30TC    |
+
+
+
+
+
+{% include 'html/rolesnavbar.md' %}

--- a/docs/Roles/Antagonist roles/Nuclear-Operative.md
+++ b/docs/Roles/Antagonist roles/Nuclear-Operative.md
@@ -9,114 +9,40 @@ Ten Hut! You have been hand picked by the [Syndicate](Groups.md) to join an elit
 
 ### How to get started
 
+As a nuke operative you will spawn at the Syndicate base or near a When you have made your plan, board the syndicate shuttle and head off towards the station (which is near 0,0. Use your nuke disk pinpointers if you need extra guidance). 
 
-As a nuke operative you will spawn aboard or near a Syndicate shuttle. This shuttle contains most of your equipment and will serve as your transport over to the station. Protect it with your life! It contains the nuke, the very thing you need to complete your mission, which cant be moved until you have almost won, as well as more guns than the crew has likely ever seen! Said guns are located in red lockers throughout the shuttle itself, alongside with your signature red hard-suit, helmet, and boots. along with these the shuttle contains plasma canisters, grenades, and oxygen gear vital for keeping you alive in the vacuum of space. Many a new nukie has died in the cold airless void because they forgot to put on a mask.
+The shuttle contains the nuke, the very thing you need to complete your mission, as well as lots of useful equipment that boarding station personnel could easily turn on you. The shuttle also has a small dedicated medical bay which comes with the furnishings to treat wounds and perform surgery. It also has oxygen gear vital for keeping you alive in the vacuum of space. Many a new nukie has died out in the cold airless void because they forgot to turn on their internals.
 
 ### Your gear and you
 
+The stock nukie gear consists of your uniform, night vision goggles, hardsuit helm, a syndicate mask, your signature red hardsuit, a pair of red magboots or black jackboots, your headset, gloves, an oxygen tank, a stalker SMG, a PDA which has your telecrystal uplink, and your trusty stetchkin pistol. 
 
-The typical nukie gear consists of your uniform, night vision goggles, hardsuit helm, a syndicate mask, your signature red hardsuit, a pair of red magboots or a pair of black jackboots, your headset, gloves, an oxygen tank, a c20r smg, telecommunication uplink, and your trusty stetchkin pistol. Your night vision does exactly what youd expect, letting you see in dark areas. The hardsuit helm and torso pieces make you immune to the cold and pressure, while offering very decent protection against weapons and explosives. You are not invincible in these however, and getting shot will still hurt. The headset doesn't let you hear the crew, but it does give you access to your own syndicate channel. The c20r will be your main offensive weapon, it is fully automatic and comparable to security's own p90, be sure to bring extra ammo for it, as it burns through magazines rapidly. the stetchkin is a small but scrappy fallback pistol. Use it if you've run out of other ammo or wish to conserve it. It is better than the security pistol but that isn't saying much. One of the best uses for the pistol, however, is getting someone out of the way, as one or two shots will usually send any unarmed crew member running. All this gear can be used along with more specialized tools, such as grenades for flushing out crew or a machine-gun for true rip-and-tear action. Be creative with your gear and strategize before hand, its how you'll win! speaking of which:
+Your night vision does exactly what youd expect, letting you see in dark areas. The hardsuit helm and torso pieces make you immune to the cold and pressure, while offering very decent protection against weapons and explosives. You are not invincible in these however, and getting shot will still hurt. The headset doesn't let you hear the crew, but it does give you access to your own syndicate channel. 
+
+The Stalker will be your main offensive weapon unless you choose to [buy something else](Syndicate Items.md) to replace it. Be sure to bring extra ammo for it, as it burns through magazines rapidly. 
+
+The stetchkin is a small but scrappy fallback pistol. Use it if you've run out of other ammo or wish to conserve it. One of the best uses for the pistol, however, is getting someone out of the way, as one or two shots will usually send any unarmed crew member running. Be creative with your gear and strategize before hand, its how you'll win! speaking of which:
 
 ### How to do your job
 
-You need to get the [Nuclear Authentication Disk](Nuclear-Authentication-Disk.md). The pinpointer in your pack will show a large arrow pointing directly to it. plan with your fellow operatives as to how you'll approach it, will you infiltrate stealthily as miners, sneak up and blow open a wall to surprise security, or ram the shuttle directly into the station? <s>Once</s> If you get the disk, you will need to bring it back to nuke and insert it in. Enter the code you got at roundstart, unlock it, drag it over to the station, start the timer, and run like hell!
+You need to get the [Nuclear Authentication Disk](Nuclear-Authentication-Disk.md). The pinpointer in your pack will show a large arrow pointing directly to it. plan with your fellow operatives as to how you'll approach it, will you infiltrate stealthily as miners, sneak up and blow open a wall to surprise security, or ram the shuttle directly into the station? <s>Once</s> *If* you get the disk, you will need to bring it back to nuke and insert it in. Enter the code you got at roundstart, unlock it, drag it over to the station, start the timer, and run like hell!
 
 ###  How to use TC Shop
 
-First what you need to do is open your PDA, go to settings, click in the textbox underneath "Change Ringtone" and type in that ***case sensitive*** code you see in chat. The code should look something like **"Echo-Hotel-Kilo-350"** Don't forget the code, not even an admin can get it back without respawning you (as of version 4116). You have a max of 20TC per round.
+First what you need to do is open your PDA, go to settings, click in the textbox underneath "Change Ringtone" and type in that ***case sensitive*** code you see in chat. The code should look something like **"Kilo-350"**. If you forget your code, you can hit the antagonist objective reminder button near the top of your screen to get a reminder what your code was. 
 
+As an operative, You start with 25TC, but you can acquire more if you declare war on the syndicate operations console. Go to the [Syndicate Items](Syndicate Items.md) page to see what you can buy. As a nuclear Operative, you get many extra options that traitors don't have access to.
 
+### This means WAR!!!
+Before you leave the base to make your attack, you have the option to declare war on the station. This is done on the Syndicate Operations Console. Prepare a threatening message and hit the big red button to declare war.
 
-| <font color="red">Conspicuous Weapons</font>       | <font color="blue">Price</font> |
-| -------------------------------------------------- | :-----------------------------: |
-| makarov 9mm Pistol                                 |  <font color="blue">7TC</font>  |
-| Energy Sword                                       |  <font color="blue">8TC</font>  |
-| Lucifer .357 Magnum Revolver 8                     |  <font color="blue">12TC</font>  |
-| Reverse Revolver                                   |  <font color="blue">8TC</font>  |
-| Stalker SMG                                |  <font color="blue">10TC</font>  |
-| Bulldozer shotgun                                       |  <font color="blue">8TC</font>  |
-| M90-gl carbine                     |  <font color="blue">18TC</font>  |
-| Buzzsaw LMG                                   |  <font color="blue">18TC</font>  |
-| Migraine .50 cal sniper rifle                                 |  <font color="blue">16TC</font>  |
-| Toy LMG                                       |  <font color="blue">10TC</font>  |
-| Toy SMG                     |  <font color="blue">5TC</font>  |
-| Surplus Rifle                                  |  <font color="blue">2TC</font>  |
-| Stechkin APS machine pistol                                 |  <font color="blue">10TC</font>  |
-| 84mm Rocket Launcher                                  |  <font color="blue">8TC</font>  |
-| Biohazardous Chemical Sprayer                                  |  <font color="blue">20TC</font>  |r
-| **<font color="red">AMMUNITION</font>**            |                                 |
-| 9mm Pistol Magazine                                |  <font color="blue">1TC</font>  |
-| 9mm Pistol Magazine AP                               |  <font color="blue">2TC</font>  |
-| 9mm Pistol Magazine Incendiary                             |  <font color="blue">2TC</font>  |
-| 9mm Pistol Magazine HP                               |  <font color="blue">2TC</font>  |
-| .357 Speedloader                                   |  <font color="blue">4TC</font>  |
-| 12g buckshot drum                                |  <font color="blue">2TC</font>  |
-| 12g Dragons Breath drum                                |  <font color="blue">2TC</font>  |
-| 12g slug drum                                |  <font color="blue">3TC</font>  |
-| .45 Magazine                                |  <font color="blue">3TC</font>  |
-| .45 Magazine Incendiary                                |  <font color="blue">4TC</font>  |
-| .45 Magazine AP                                |  <font color="blue">5TC</font>  |
-| 7.12 Box Magazine                                |  <font color="blue">6TC</font>  |
-| 7.12 AP Box Magazine                                |  <font color="blue">9TC</font>  |
-| 7.12 Incendiary Box Magazine                                |  <font color="blue">6TC</font>  |
-| 7.12 HP Box Magazine                                |  <font color="blue">6TC</font>  |
-| 7.12 MatchBox Magazine                                |  <font color="blue">9TC</font>  |
-| .50 Sniper Magazine                               |  <font color="blue">4TC</font>  |
-| .50 Penetrator Sniper Magazine                               |  <font color="blue">5TC</font>  |
-| .50 Soporific Sniper Magazine                               |  <font color="blue">6TC</font>  |
-| 5.56 Magazine                                |  <font color="blue">4TC</font>  |
-| 5.56 Magazine Phasic                                |  <font color="blue">8TC</font>  |
-| 40mm Grenade Rounds Box                                |  <font color="blue">6TC</font>  |
-| 84mm HE Rocket                                |  <font color="blue">4TC</font>  |
-| 84mm HEDP Rocket                                |  <font color="blue">6TC</font>  |
-| 9mm stechkin Pistol Magazine                                |  <font color="blue">2TC</font>  |
-| Riot Dart Box                               |  <font color="blue">2TC</font>  |
-| <font color="red">**EXPLOSIVES**</font>            |                                 |
-| Syndicate Minibomb                                 |  <font color="blue">6TC</font>  |
-|  C4                             | <font color="blue">1</font> |
-|  X4                             | <font color="blue">4</font> |
-|  Pizza Bomb                     | <font color="blue">10</font> |
-| Grenadier's Belt | <font color="blue">24</font> |
-| EMP grenade box | <font color="blue">10</font> | 
-| <font color="red">**STEALTHY WEAPONS**</font>      |                                 |
-| Energy Dagger                                      |  <font color="blue">2TC</font>  |
-| Miniature Energy Crossbow                          | <font color="blue">10TC</font>  |
-| Syndicate Holster                                  |  <font color="blue">1TC</font>  |
-|  Suppressor                     | <font color="blue">3TC</font>  |
-| <font color="red">**SUITS**</font>                 |                                 |
-| Syndicate Spacesuit                                |  <font color="blue">4TC</font>  |
-| Syndicate Hardsuit                                 |  <font color="blue">8TC</font>  |
-| Elite Syndicate Hardsuit                                 |  <font color="blue">8TC</font>  |
-| Shielded Hardsuit                                 |  <font color="blue">30TC</font>  |
-| <font color="red">**MISC. GADGETS**</font>         |                                 |
-| Blood-Red Magboots                                 |  <font color="blue">2TC</font>  |
-| Chest Rig                                          |  <font color="blue">1TC</font>  |
-| Cryptographic Sequencer                            |  <font color="blue">6TC</font>  |
-| Full Syndicate Toolbox                             |  <font color="blue">1TC</font>  |
-| Syndicate Soap                                     |  <font color="blue">1TC</font>  |
-| Jaws Of Life                                     |  <font color="blue">4TC</font>  |
-| Syndicate Reinforcement                                 |  <font color="blue">25TC</font>  |
-| Syndicate Soap                                     |  <font color="blue">1TC</font>  |
-|  Surgical Equipment Bundle      | <font color="blue">3TC</font> |
-| <font color="red">**(POINTLESS) BADASSERY**</font> |                                 |
-| Syndicate Balloon                                  | <font color="blue">20TC</font>  |
-| Syndicate Briefcase Full of Cash                   |  <font color="blue">1TC</font>  |
-| Syndicate Smokes (cigarette)                       |  <font color="blue">2TC</font>  |
-| <font color="red">**Bundles**</font>               |                                 |
-| TC withdrawal (choose 1, 5, 10, or 20)                   |  <font color="blue">varies</font>  |
-| Bioterror Bundle                   |  <font color="blue">30TC</font>  |
-| Bulldozer Bundle                  |  <font color="blue">13TC</font>  |
-| Stalker Bundle                   |  <font color="blue">14TC</font>  | 
-| Sniper Bundle                   |  <font color="blue">20TC</font>  |
-| Spetznas Pyro Bundle                   |  <font color="blue">30TC</font>  |
+Declaring war takes away one of your largest advantages because the entire station now knows you are coming, letting them prepare defenses against you. The advantage you get for doing so is a lot a of bonus TC; Near the operations console will be a few TC Withdrawal stations, each of which will dispense extra TC every minute for 20 minutes, giving you a total of 280TC extra to buy loads of fun equipment you can't normally afford to buy. 
 
+There is no requirement to wait until the full 280TC has been dispensed, and it is advised that once you've made all the purchases you want, start heading for the station ASAP, as the longer you wait, the more time they have to prepare for your arrival.
 
 ### How to improve
 
-Nuke ops are generally very confrontational. Unlike most traitors you cant use the argument that you mean no harm, as you absolutely do. As such you will spend most of your time running around and shooting things. To get better at this, you can play <s>a catgirl clown</s> [security](Security.md). If your doing this, try being on patrol and responding to shootouts as often as possible. Maybe, just maybe, you could [[So close to impossible that it might as well not even exist|figure out a peaceful approach?]]
-
-### WAR!!!!
-Nuclear operatives are able to declare war on the station, alerting the crew. After doing this, they will slowly gain telecrystals over 20 minutes, to a maximum of 280 TC. 
+Nuke Ops is generally a very confrontational gamemode. Unlike traitors, you cant use the argument that you mean no harm, as you absolutely do. As such you will spend most of your time running around and shooting things, though if you are very smart about it, you can go for the sneaky route. To get better at the running and gunning, you can play <s>a catgirl clown</s> [security](Security.md). Go on patrol and respond to shootouts as often as possible. Or, if you are the diplomatic type, maybe, just maybe, you could [figure out a peaceful approach?](So-close-to-impossible-that-it-might-as-well-not-even-exist.md)
 
 
 {% include 'html/rolesnavbar.md' %}

--- a/docs/Roles/Antagonist roles/Traitor.md
+++ b/docs/Roles/Antagonist roles/Traitor.md
@@ -7,102 +7,67 @@
 Traitor is one of the three types of Antagonist roles that can spawn, with the other two currently in the game being [Nuke Ops](Nuclear-Emergency.md) and [Cargonia](Cargonia.md).
 
 
-### MISSION SPECIFICATION DECRYPTED. WELCOME, SYNDICATE AGENT.
+### MISSION SPECIFICATIONS DECRYPTED. WELCOME TO THE SYNDICATE.
 
-As a Traitor, you spawn as the role you selected, with no visual distinction from everyone else. However, you are massively different from any other crew member: You're part of the [Syndicate](Groups.md). Maybe you're a hardcore follower of the Syndicate ways; maybe you're just some poor sap who was in the wrong place at the wrong time. Either way, you have one job: [|Complete your objectives without giving away your true identity.](So-close-to-impossible-that-it-might-as-well-not-even-exist.md)
+As a Traitor, you spawn as the station role you selected, with no visual distinction from everyone else. However, you are massively different from any other crew member: You're part of the [Syndicate](Groups.md). Maybe you're a hardcore follower of the Syndicate ways; maybe you've just got a score to settle; or maybe you're just some poor sap who was in the wrong place at the wrong time and now you've been blackmailed into service. Whatever your motivation is, you have one job: [Complete your assigned objectives.](So-close-to-impossible-that-it-might-as-well-not-even-exist.md)
 
-Traitors get 3 objectives, shown at the round start in the chat: Steal a random high-tier item, assassinate a random crew member (often a department head), and survive untill the end of the round. An example of what your objectives could be:
+Traitors get 3 objectives, shown at the round start in the chat: Steal a random high-tier item, assassinate a random crew member (often a department head), and survive until the end of the round. An example of what your objectives could be:
 
 - Steal the Chain of Command (found in the captain's quarters)
 - Assassinate Mr. Engineering man sir, [Chief Engineer](Chief-Engineer.md)
 - Escape on the [Emergency Shuttle](Emergency-Shuttle.md) alive
 
-## Getting weapons and other stuff from your magic PDA
+Remember, if you ever need a reminder of what they are (or need to remember your uplink code) hit the objective reminder button at the top of the screen. It looks like a pair of bloody shoes.
 
-At the start of your round as traitor, you will be given a password that you must put on the ringtone changer in your PDA, that password is usually composed of three NATO alphabet letters separated by dashes, another dash and three numbers. When you open your PDA, you go to options and below where it says ringtone changer you enter the password. Then, you will get to a screen that has weapons. Be sure to have your off hand empty and the items you select will be teleported there. However, the items cost credits, and you have only 20 of those to start.
+## Buying weapons and equipment from the Telecrystal Uplink
+
+One of the most important items to you as a traitor is your PDA. In order to assist in your mission, the syndicate have incorporated an uplink that allows you to purchase a limited selection from a large list of weapons and tools.
+
+At the start of your round as traitor, you will be given a *case-sensitive* password composed of a NATO alphabet letter and three numbers that you put on the ringtone changer under the options menu in your PDA. You will get to a screen that has weapons. Be sure to have your off hand empty or the items you purchase will drop onto the floor. However, the items cost a special finite resource called telecrystals (TC), and you have only 20 to spend, so make your purchases carefully. 
+
+Acquiring more TC is functionally improbable, as it requires you to kill another traitor who has their own uplink *still unlocked* and *they haven't spent it all.*
+
+###### To see what's available to buy and some general footnotes about the items, go [here.](Syndicate Items.md)
 
 
 
-| <font color="red">Conspicuous Weapons</font>       | <font color="blue">Price</font> |
-| -------------------------------------------------- | :-----------------------------: |
-| Makarov 9mm Pistol                                 |  <font color="blue">7TC</font>  |
-| Energy Sword                                       |  <font color="blue">8TC</font>  |
-| Lucifer .357 Magnum Revolver 8                     |  <font color="blue">9TC</font>  |
-| Reverse Revolver                                   |  <font color="blue">8TC</font>  |
-| **<font color="red">AMMUNITION</font>**            |                                 |
-| 9mm Pistol Magazine                                |  <font color="blue">1TC</font>  |
-| 9mm Pistol Magazine AP                                |  <font color="blue">2TC</font>  |
-| .357 Speedloader                                   |  <font color="blue">4TC</font>  |
-| <font color="red">**EXPLOSIVES**</font>            |                                 |
-| Syndicate Minibomb                                 |  <font color="blue">6TC</font>  |
-| <font color="red">**STEALTHY WEAPONS**</font>      |                                 |
-| Energy Dagger                                      |  <font color="blue">2TC</font>  |
-| Miniature Energy Crossbow                          | <font color="blue">10TC</font>  |
-| Supressor                          | <font color="blue">3TC</font>  |
-| Syndicate Holster                                  |  <font color="blue">1TC</font>  |
-| <font color="red">**SUITS**</font>                 |                                 |
-| Syndicate Spacesuit                                |  <font color="blue">4TC</font>  |
-| Syndicate Hardsuit                                 |  <font color="blue">8TC</font>  |
-| <font color="red">**MSIC. GADGETS**</font>         |                                 |
-| Blood-Red Magboots                                 |  <font color="blue">2TC</font>  |
-| Chest Rig                                          |  <font color="blue">1TC</font>  |
-| Cryptographic Sequencer                            |  <font color="blue">6TC</font>  |
-| Full Syndicate Toolbox                             |  <font color="blue">1TC</font>  |
-| Syndicate Soap                                     |                                 |
-| <font color="red">**(POINTLESS) BADASSERY**</font> |                                 |
-| Syndicate Balloon                                  | <font color="blue">20TC</font>  |
-| Syndicate Briefcase Full of Cash                   |  <font color="blue">1TC</font>  |
-| Syndicate Smokes (cigarette)                       |  <font color="blue">2TC</font>  |
-| <font color="red">**Bundles**</font>               |                                 |
-| N/A                                                |                                 |
+## [Theft](High-Risk-Items.md) objectives
 
-## The treachery tricks
+Often one or both of your objectives requires you to steal something. How hard this is depends on the item and whether the job that starts with it is filled by another player. 
 
-As a traitor, you must kill a person and get an item. In small rounds (little players, not all the roles covered), that means entering a high security area and sooting down a locker and killing someone. In big rounds it means killing a higher up and praying they have their item on them, and then killing some random dude. As the higher ups are usually at least half competent at the game, this is a hard task, not even taking into account security. However, there are some things you can do:
+Theft objectives will often require you to break into secure areas or to steal the items directly off of other players. Sometimes it will be shockingly easy, easier than taking candy from a baby. Other times it will be [so impossible](So-close-to-impossible-that-it-might-as-well-not-even-exist.md) that you should probably take the L and try to have fun getting up to shenanigans with your exclusive traitor items. It all depends on what state the station is in and how many players are alive. Still, woe betide anyone who gets the objective `steal the Justitia.`
 
-### Get a gun
+###### to see a complete list of steal objects you can expect to get, take a look at the [High Risk Items](High-Risk-Items.md) page.
 
-The basic p90 pistol and as much ammo as you can is the blind pick, however you can also go with the more expensive gun and its ammo (im not sure if it works tho). If you manage to get the Justitia or the Imperitor, don't use them, they don't work for you because of a thing of access that I have no idea of how it works, but you will probably need their keycards or something. Also try to get as much ammo as you can, because it is really hard to get some on most stations.
-If you run out of bullets DO NOT BUY ANOTHER GUN, the ammo boxes are way cheaper and have more rounds.
+## Murder objectives
 
-### Don't spend all of your money
+Another common objective is to murder a particular crewmember on the station. Sometimes this can be challenging, but engineering someone's death can often be as simple as asking them to come to your office to look at this 'problem' and then shooting them in the back of the head with a silenced makarov. The harder part is usually getting away with it, especially if you commit the murder early in the round. 
 
-Its UnityStation, you never know what is going to happen. You may have lost your gun or you just ran out of ammo. Usually saving money for later wont kill you, but not having any might.
+Honestly, one of the best pieces of advice to take to heart with murder objectives it to take your time, play it safe, build up a relationship with the target and other gullible crewmembers, and waiting for a perfect time to strike. Heck, given how a typical round of UnityStation goes, it's likely that after a long enough amount of time, they will have died to some other threat on the station, taking care of your objective for you. When that happens, just ensure that they *stay dead.* If their body ends up being brought to medical, they will likely get revived or cloned, which will set you back to square one.
 
-### Get access
+## General Tips: 
 
-Your first task is to either get as much access as you can through the HoP, getting or stealing a card with all access or in the worst case getting a wire cutter, some wires and a screwdriver and start hacking open some doors. You need to go to all the places you can to get your items, and the captain's bedroom may be the place you need to be.
+#### Consider saving some TC for a rainy day.
 
-### Make others grief
+Its UnityStation, you never know what is going to happen. You may have lost your gun or you just ran out of ammo. Maybe you're trapped in a rapidly deteriorating station and all you need is a toolbox to hack yourself out of a depowered room. Not spending all of your TC at once will lend you some valuable flexibility in the late game. 
 
-As a traitor, your best trait is not that you can grief, but that you can make others grief. Recruit some people and be amazed of how many of them are willing to join the syndicate. People like to grief, and you are giving them the ultimate excuse to grief others, treachery. This works even in HRP servers of hardcore ss13, and will often go unpunished because of the power of friendship. Remember to try to convince people 1 on 1 if you can. I don't know why, but it seems to work best. Also beware, now they are traitors just as you, and they may betray you as well.
+#### Acquire access.
 
-### Be polite
+One great way to improve your odds of success is to acquire additional access, either through the proper way of asking the [Head of Personnel](Head-of_Personnel.md) to upgrade your clearance or by more nefarious means such as stealing another person's ID card. You need to go to all the places you can to get your items, and the captain's bedroom may be the place you need to break into to complete your objectives, and it's a lot easier and less conspicuous to get in there with an ID card than by hacking or emagging the door or by cutting through the walls.
 
-This may be the best advice you can take. Somehow, if you are polite people can even turn a blind eye on you TRYING TO MURDER THEM if they are not entirely aware of your status as a traitor. If there is no shitcurity this round, they are going to pick the mean guy, and you are not the mean guy, BECAUSE YOU ARE POLITE. You are a traitor, so you will have to betray them, but you can make them WANT to be betrayed, because you are such a nice guy, mostly because they are role playing, and you are making them feel better being betrayed than not.
+#### Be polite
 
-### Go for that kill, but not in public
+This may be the best advice you can take. Somehow, if you are polite people can even turn a blind eye on you *trying to murder them* if they are not entirely aware of your status as a traitor. When people start to look for others to blame, they are inclined to pick the mean guy, so being friendly, helpful, and generally cooperative can often set you up for success under quite incriminating circumstances. 
 
-Get a good RP reason to make people you want to kill to be alone with you when you want to kill them and where you want to kill them. Preferably when the rest of the station is in chaos. You should space the person you killed if you can, because if they are cloned they may start "remembering" stuff from their past life.
+This can extend even as far as when you've already been captured and brigged, as a positive and understanding attitude can keep your sentence short. Please, if you are lucky enough to have a [lawyer](Lawyer.md) available to you, *consult with them. They are your best chance at avoiding a permanent sentence or execution. They might even get your charges completely thrown out on occasion.* 
 
-### Go fast
+#### Miscellaneous tips:
 
-Lag and people being distracted makes swift and effective actions often go unnoticed. If you are lucky and fast enough, you may even go through the entire command room, get to the captain bedroom and loot everything without being noticed.
+- Most security firearms are equipped with ID locked electronic firing pins which will not allow you to shoot their weapons without having security clearance. This makes stealing their gear an unreliable strategy. There are a few notable exceptions, such as the stun baton, which is a very effective ambush weapon that you should steal if you can manage it. Handcuffs are another good pick.
+- Never underestimate the power of slippables like banana peels and soap. Many haughty crewmembers have met their end at the hands of a Clown dragging around a peel behind him, only to be bludgeoned into unconsciousness while down and thrown into space.
+- You can impersonate another person by wearing a face covering and putting on their ID card. Talking will give away your identity in chat, but as long as you stay silent, you will identify as whatever name is recorded on the ID. Wearing a space suit or some other total body covering will help sell the false identity even further.
+- Even if it seems like you are alone, beware of security cameras. If there's an active [statiom AI,](Station-AI.md) it's impossible to predict when they have their eye on you and when they don't. Do your dirty business out of sight, such as in maintenance tunnels or, if you must, disable security cameras in the areas you have to operate in. Disabling cameras is risky, though, as they or another bystander might see you do it. The new blind spot might catch the AI's attention as well.
 
-### Just shoot
 
-People don't give a fuck about hearing a gunshot, its unitystation, thats part of the job and as long as you haven't seen any traitors shooting, the shot is far and not important. This is not among us and probably no one is going to check who was the "big bad traitor who killed my buddy", so don't wait for it, make your moment and role play your way out. This may not be Dwarf Fortress since losing is not fun always, but it can be if you get permajailed after a really good phoenix wright simulator in a space station.
-
-### Helpful locations and how to get there
-
-- The lockers have to be shot down if you want to get whats inside of them and don't have access. Get a gun.
-- The Justitia is the HoS big laser gun and is on his locker on his office on security. He should have it on himself at all times (unless he´s VERY incompetent)
-- The Imperator is the Capitan's big laser gun and is on his locker on his bedroom on command. This gun is actually pretty good but not flawless nor critical to his role, so the captain should have it on himself but not always.
-- The chain of command is a chain whip on the captain's bedroom, he may or may not have it on him.
-- The nuclear disk is the thing you use to turn on the nuke to the side of the captain's bedroom (you also need a password, so don't try it unless you are nuke ops or similar). Its in the captain's bedroom, but he probably already took it.
-
-## Grief and have fun
-
-If you don't want to do any hard work and just want to grief like a boss, you can. You are a traitor, anyway, so you can always argue its to "get your objectives done", because you need chaos to do so, and unitystation is always chaos (at least it should work in a MRP server). Kill that clown because you don't like him and BECOME the clown. Steal a plasma canister and blow half the station to pieces. You name it. You are the bad guy, you can always just roleplay a dick, but expect security to get you and put you into jail, or to die to the people you are trying to grief.
 
 {% include 'html/rolesnavbar.md' %}


### PR DESCRIPTION
This PR performs a near total rewrite of the Nuclear Operative, Traitor, and Syndicate Items pages. My general goal was to update the wording of the nukie and traitor pages to a higher standard of writing and to convey more useful information. In order to reduce the amount of redundant information in all three pages, the uplink item tables in the Nukie and Traitor pages were nixed and all of their relevant information was moved into the Syndicate Items page. 

This ensures that we don't have the same information written in three different places and boils down the 2 antag pages to the most general information to convey more clearly _how they play,_ leaving all the noodly purchase strategizing to the Syndicate Items page. Doing this saves like 160 lines of text.

A portion of the nukie page and a large majority of the traitor page were very out of date, and this PR updates them to reflect the new gameplay additions of the past year. the PR fixes #55, as a result. 

Amongst all that, there were several grammar and punctuation fixes and a lot of links to other pages were added which should help improve page navigation.