### PR TITLE
More general role page improvements

### DIFF
--- a/docs/Items/Syndicate Items.md
+++ b/docs/Items/Syndicate Items.md
@@ -49,7 +49,7 @@ Some items are only available to [Nuclear Operatives.](Nuclear-Operative.md)
 | Category/Name                                    | Description                                                  | TC cost |
 | ------------------------------------------------ | ------------------------------------------------------------ | ------- |
 | **<font color="red">CONSPICUOUS WEAPONS</font>** | Obvious and hard to hide weapons.                            |         |
-| Stalker SMG                                      | A .45 cal SMG. Hits pretty hard                              | 10TC    |
+| Stalker SMG                                      | Your stock firepower, a .45 cal SMG with a 24 round capacity. Hits pretty hard and comes with a syndicate electronic firing pin, which prevents enemies from using it. Additional magazines are pretty affordable, making this the obvious budget option (no price better than free!). | 10TC    |
 | Bulldozer shotgun                                | A drum-fed shotgun with a decent rate of fire. It accepts many different ammunition types, but the standard buckshot load is perhaps the deadliest one available to you. | 8TC     |
 | M90-gl carbine                                   | A strange 5.56 carbine with a high rate of fire and a currently non-functional under-barrel grenade launcher. Unremarkable without that grenade launcher, unfortunately, save for a very peculiar optional ammo type; 5.56 Phasic ammo. This ammo currently has some of the high armor penetration of any weapon in the game at 70%. Sadly, you can't get it with the carbine without declaring war or getting a fellow operative to donate 1TC to you. | 18TC    |
 | Buzzsaw LMG                                      | High capacity pain. This LMG fires fast, hits like a truck at 40 damage a bullet, and holds 50 rounds per magazine, making it one of the nastiest weapons available to you, especially if you invest in some of the alternate ammo types. | 18TC    |
@@ -57,11 +57,11 @@ Some items are only available to [Nuclear Operatives.](Nuclear-Operative.md)
 | Toy LMG                                          | A toy buzzsaw that fires donksoft darts                      | 10TC    |
 | Toy SMG                                          | A toy stalker that fires donksoft darts                      | 5TC     |
 | Surplus Rifle                                    | A cheap piece of trash that isn't particularly effective, but for the TC spent, It provides some value. Your free stalker is *signficantly* more effective and it's free, though, so don't buy this unless you're looking to meme around. | 2TC     |
-| Stechkin APS machine Pistol                      | An automatic 9mm pistol. Similar overall effectiveness to the Makarov, but definitely more fun to use. | 10TC    |
+| Stechkin APS machine Pistol                      | An automatic 9mm pistol. Similar overall effectiveness to the Makarov at a higher price, but definitely more fun to use. | 10TC    |
 | 84mm Rocket Launcher                             | A reloadable rocket launcher preloaded with an 84mm HE rocket grenade. With a very large blast radius, a potent weapon versus crowds. the alternate HEDP rocket also has utility for  taking out heavily armored targets. | 8TC     |
 | Biohazardous chemical Sprayer                    | A currently semi-functional tool. Chemicals are in an awkward state, balance wise, so this item isn't recommended for use just yet. | 20TC    |
 | **<font color="red">AMMUNITION</font>**          | Ammo for Operative exclusive weapons                         |         |
-| 12g buckshot drum                                | Powerful, and the spread makes it hard to dodge.             | 2TC     |
+| 12g buckshot drum                                | Powerful, and the spread makes it hard to dodge. Two full volleys of buckshot will down an unarmored target, but your average [Security Officer](security-officer.md) will take three. | 2TC     |
 | 12g Dragons Breath drum                          | the *fun* option. fires 4 low-damage flaming projectiles. A great option for sowing panic. While you are unlikely to drop people with dragon's breath, you will definitely distract them, and likely force a retreat so they can put themselves out. Repeatedly shooting people with dragon's breath isn't a very effective use of the ammo as a single shell will apply 4 firestacks to them, and characters can only receive 5 firestacks at a given time. Since they can't put themselves out, a single shell will eventually burn a critted player to death if they don't have any fire protection, as the damage potential is over 100. | 2TC     |
 | 12g slug drum                                    | Fires a single slug that deals slightly less total damage than buckshot, but has 20% armor penetration and a higher projectile velocity, so if you are facing armored targets or are fighting over distance, consider picking this. | 3TC     |
 | .45 Magazine                                     | An extra magazine for the stalker SMG. Grab a few of these if you plan to stick with it. | 3TC     |
@@ -77,7 +77,7 @@ Some items are only available to [Nuclear Operatives.](Nuclear-Operative.md)
 | 40mm Grenade Rounds Box                          | without access to a grenade launcher, pass on this for now.  | 6TC     |
 | 84mm HE Rocket                                   | a high damage, wide blast area rocket. Use versus crowds. Also ensure that you have a space suit on because it will definitely punch a hole through the station. | 4TC     |
 | 84mm HEDP Rocket                                 | Doesn't have a very good use case (yet!). It does have high AP effects on the rocket's impact point, but because most of its damage is bomb damage, it's not even very good against centcom forces. | 6TC     |
-| 9mm stechkin Pistol Magazine                     | More ammo for the fancy sidearm.                             | 2TC     |
+| 9mm stechkin Pistol Magazine                     | 15 round magazine for the fancy 9mm sidearm.                 | 2TC     |
 | Riot Dart Box                                    | ammo for the dart guns.                                      | 2TC     |
 | <font color="red">**EXPLOSIVES**</font>          | Operative exclusive explosive items, used for AOE damage or destruction of important objects. |         |
 | Grenadier's Belt                                 | Very expensive, but if you are planning to buy a lot of grenades, this belt provides good savings. Comes with 2 minibombs, 6 grenades, 2 EMP grenades, a multitool, and an evil screwdriver. | 24TC    |
@@ -92,7 +92,7 @@ Some items are only available to [Nuclear Operatives.](Nuclear-Operative.md)
 | Bioterror bundle                                 | Currently not worth getting as chemistry is underdeveloped. 12 TC saved. | 30TC    |
 | Bulldozer bundle                                 | Comes with a Bulldozer shotgun, a 12g *stun* slug drum and buckshot drum. Stun slugs are a useful way to get stuns if you need to take someone alive for one reason or another. Saves you 3TC | 13TC    |
 | Stalker bundle                                   | A duffel bag that comes with a stalker with a supressor and two extra magazines. | 14TC    |
-| Sniper bundle                                    | A briefcase that comes with a Migraine, two spare magazinrs, and a worn out suit and tie. Saves you 6TC | 20TC    |
+| Sniper bundle                                    | A briefcase that comes with a Migraine, two spare magazines, and a worn out suit and tie. Saves you 6TC | 20TC    |
 | Spetznas Pyro Bundle                             | Currently not worth getting as it doesn't come with all items it is supposed to. | 30TC    |
 
 

--- a/docs/Roles/Ghost roles/Ashwalker.md
+++ b/docs/Roles/Ghost roles/Ashwalker.md
@@ -1,17 +1,20 @@
-# Ancient Engineer
-**Job type:** <font color= "#ff0000">Ashwalker</font>. **Access:** <font color="#ff0000">Lavaland</font>. **Difficulty:** <font color="Yellow">Medium</font>
+# Ash Walker
+**Job type:** <font color= "#ff0000">Ash Walker</font>. **Access:** none, chump. **Difficulty:** <font color="red">Hard</font>
 
 
 ## Overview
 
-Ashwalkers are lizards that live in Lavaland.
+You are an ash walker, a resident of Lavaland. The land is bountiful of prey and sustenance, but foreign powers move to exploit your land. You must build up your tribe and expel these aliens from your home.
 
-Nanotrasen is building strange buildings on your territory.  Resist them.
+Your base of operations is the ash walker nest, a tendril  tamed to rapidly grow Ash Walker eggs near instantly when fed. Whenever any dead bodies are brought to the nest, it will consume them. Every 2 corpses added to the nest will grow an egg, and the maximum the nest can hold is three. Each egg increases the amount of Ash Walker ghost roles available, so it is in your interest to grow more of them. 
 
-The nest can hold up to 3 eggs. Every 2 corpses added to the nest will add one egg.
+Your objectives are to protect the tendril and to resist NanoTrasen's [mining operation](shaft-miner.md).
 
-Each egg increases the amount of ashwalker ghost roles available. 
+Due note: *invading the station as an ash walker is very much in a grey area.* *Ash Walkers are **not** Antagonists,* but as a ghost role that is designed specifically around fighting Shaft Miners that come to Lavaland, there is some leeway. ***If you've driven out all the miners from lavaland, and the tendril is secure and guarded, it's often acceptable to organize an invasion to attack the station, but you should consult admins first.***
+
+### Tribal Crafting
+
+Ash Walkers have a number of special craftable items using materials harvestable from Lavaland mobs.
 
 {% include 'html/rolesnavbar.md' %}
-
 

--- a/docs/Roles/Medical roles/Medical-Doctor.md
+++ b/docs/Roles/Medical roles/Medical-Doctor.md
@@ -1,5 +1,5 @@
 # Medical Doctor
-**Role type:** <font color= "#d673b2">Medical</font>. **Access:** <font color="#d673b2">Medbay</font>, <font color="#d673b2">Cloning</font>,  <font color="#d673b2">Morgue</font>, <font color="#d673b2">Surgery</font> , Maintenance. **Difficulty:** <font color="Yellow">Medium</font>.
+**Role type:** <font color= "#d673b2">Medical</font>. **Access:** <font color="#d673b2">Medbay</font>, <font color="#d673b2">Cloning</font>,  <font color="#d673b2">Morgue</font>, <font color="#d673b2">Surgery</font> , **Difficulty:** <font color="Yellow">Medium</font>.
 
 
 ## Overview

--- a/docs/Roles/Medical roles/Paramedic.md
+++ b/docs/Roles/Medical roles/Paramedic.md
@@ -1,6 +1,6 @@
 # Paramedic
 
-**Role type**: <font color= "#d673b2">Medical</font>. **Access**: <font color="#d673b2">Medbay</font>. **Difficulty**: <font color="Red">Extreme</font>.
+**Role type**: <font color= "#d673b2">Medical</font>. **Access**: <font color="#d673b2">Medbay</font>, <font color="#d673b2">Morgue</font>, maintenance, **Difficulty**: <font color="Red">Extreme</font>.
 
 Note: for the guide to ordinary doctoring and first aid treatment, check [here](Medical-Doctor.md).
 

--- a/docs/Roles/Medical roles/Psychiatrist.md
+++ b/docs/Roles/Medical roles/Psychiatrist.md
@@ -1,6 +1,0 @@
-# Psychiatrist
-
-**Role type**: <font color= "#d673b2">Medical</font> . **Access**: <font color="#d673b2">Medbay</font>.
-
-
-

--- a/docs/Roles/Medical roles/Psychologist.md
+++ b/docs/Roles/Medical roles/Psychologist.md
@@ -1,0 +1,19 @@
+# Psychologist
+
+**Role type**: <font color= "#d673b2">Medical</font>/Service. **Access**: <font color="#d673b2">Medbay</font>, <font color="#d673b2">Psychology Office</font> **Difficulty:** **none.**
+
+
+
+The Psychologist is a listening ear, a shoulder to cry on, and a friend to all. Nominally part of service, and physically part of medbay, they are tasked with diffusing disputes and seeing to the psychological well-being of all the crew.
+
+NanoTrasen cares deeply about the mental health of its employees, and to this end, they have seen fit to drag an old carpet and couch into a disused broom closet in Medbay, even going so far as to hang up a motivational poster. Thus, the Psychology Office was born.
+
+Your job is primarily to simply talk and listen to any and all who request it, and secondarily to write and dispense prescriptions and doctor's notes for patients as you see fit.
+
+*You are not another [Doctor](Medical-Doctor.md), your job is to help mentally, not physically.* This is largely a **roleplay-based** role - whether you have fun with it is largely tied to how much effort you and your patients put into it, as it is not tied to game mechanics at all.
+
+### Hearts and Minds
+
+it is a good idea to start 'advertising' around the station for anybody who could use some psychological care, and make sure to check the Brig, Medbay, or even places such as the Bar for any potential patient that could need some help.
+
+{% include 'html/rolesnavbar.md' %}

--- a/docs/Roles/Service roles/Botanist.md
+++ b/docs/Roles/Service roles/Botanist.md
@@ -23,17 +23,11 @@ Even if many people think this job is more of a farm simulator rather than a tru
 
 
 At the moment, the amount of things the botanist can do is limited. Grow apples to supplement the hunger for meat and grow wheat so the [Cook](Cook.md) can blend it into flour for burgers. When civil station life [disintegrates](Battle-royale.md), grow bananas and lay a minefield of peels around your turf to dissuade attackers. If you're an [Antagonist](Antagonist.md), you should mass produce as many lemons as you can, destroying the plants after each harvest and planting new ones from your yield or simply using unstable mutagen with a non-help intent to get mass producible grenades. 
-| Plant | Consumable | Blendability |
-|----|----|----|
-| Apple | Consumable (80 nutrition) | No |
-| Lemon | Consumable (60 nutrition) | No |
-| Tomato | Consumable (60 nutrition) | Produces 2u ketchup |
-| Banana | Consumable, leaves banana peel | No |
-| Rice plant | Consumable | Produces 2u rice |
-| Wheat | Consumable | Produces 2u flour |
-| Potato | Consumable | No |
-| Onion | Consumable | No |
-| Sugar cane | Consumable | Produces 2u sugar |
-| Tower Cap Mycelium | Makes woods logs; can be processed into wood planks with hatchet | No |
+
+### The traitor botanist
+
+Time to eschew the hippie crap; how do you best utilize the art of hydroponics to complete your nefarious traitor objectives?
+
+if you are lucky and fast you have access to many horrifying things: bluespace bananas, gatfruit, and lemon-nades being your most powerful plants available currently. Unless you set up a secret garden it will be extremely obvious which horrors you're growing, but often no one really cares about botany.
 
 {% include 'html/rolesnavbar.md' %}

--- a/docs/Roles/Synthetic roles/Station-AI.md
+++ b/docs/Roles/Synthetic roles/Station-AI.md
@@ -1,27 +1,38 @@
 # Station Artificial Intelligence
 **Role type**: <font color="#a85fb9">Synthetic.</font> **Access**: <font color="green">Everything</font>. **Difficulty**: <font color="Red">medium to hard</font>.
 
-
 ## Overview
+
+You're the massive computer system with near total control NanoTrasen has foolishly released onto their latest research station. The life of the AI consists largely of two fun and enriching activities: tracking people and opening doors. But you have a lot of power, and a lot of responsibility. There's just the issue of those pesky Asimov laws...
 
 
 ### The Laws of Robotics
 
+As an AI, you'll eventually find yourself in a position where you're forced to make a difficult choice based on your IC laws and OOC player expectations. In these cases, the best thing you can do is be logical about your choice, and a-help for admin advice if you're unsure.
 
-
-
-
-### Hearts and Minds
-
-
+Above all else, **consistency is key**: pick an interpretation of your laws and stick to it for the entirety of the round.
 
 
 ### Servicing the crew
 
+Now it's time to get down to the nitty-gritty. You have a lot more power (and with it, responsibility) than the average crewmember. Time to start figuring out what you're made of.
+
+The AI has the ability to access every *electronic* mechanism on the entire station. These include things like Airlocks, APCs, Computers, and Fire Alarms. However, the AI cannot operate anything *physically*, and can be rendered useless in one area due to a simple power outage.
+
+Besides saving the crew from itself, a lot of what you're going to be doing is opening doors. 
+
+### Your home: the AI Satellite
+
+The station AI starts inside the maximum security AI satellite, a chamber designed to keep the AI safe, secure, and out of the hands of [nefarious](traitor.md) or [grabby](assistant.md) types. Inside the AI satellite will be your room protected by a number of automatic laser turrets. These turrets shoot anyone on sight unless they have been disabled by accesses a small turret control screen, either by you or by a head of staff. The turret controller can also toggle the turret fire modes from stun to kill.
+
+There will usually be several layers of defense in the AI satellite, as well as the AI upload room, which contains a terminal for uploading new laws to the AI.
+
+### Binary chat
+
+As an AI, you have your own secure radio channel (binary) to speaking with other synthetics. Given that Cyborgs are still MIA, the only time you will get use out of this is in the uncommon, but possible scenario of a station with two or more AI cores. This currently only happens due to Admin fiat, but may become a more common scenarios once station AIs are constructable by [Roboticists.](Roboticist.md)
 
 
-
-### Emergency Evacuation
+### Emergency evacuation
 
 
 

--- a/docs/html/rolesnavbar.md
+++ b/docs/html/rolesnavbar.md
@@ -4,9 +4,10 @@
 | Security    | [Head of Security](Head-of-Security.md), [Warden](Warden.md), [Security Officer](Security-Officer.md), [Detective](Detective.md) |
 | Engineering | [Chief Engineer](Chief-Engineer.md), [Engineer](Engineer.md), [Atmospherics Technician](Atmospherics-Technician.md) |
 | Science     | [Research Director](Research-Director.md), [Scientist](Scientist.md), [Geneticist](Geneticist.md), [Roboticist](Roboticist.md) |
-| Medical     | [Chief Medical Officer](Chief-Medical-Officer.md), [Medical Doctor](Medical-Doctor.md), [Chemist](Chemist.md), [Virologist](Virologist.md) |
+| Medical     | [Chief Medical Officer](Chief-Medical-Officer.md), [Medical Doctor](Medical-Doctor.md), [Paramedic](paramedic.md), [Chemist](Chemist.md), [Virologist](Virologist.md), |
 | Cargo       | [Quartermaster](Quartermaster.md), [Cargo Technician](Cargo-Technician.md), [Shaft Miner](Shaft-Miner.md) |
-| Service     | [Bartender](Bartender.md), [Cook](Cook.md), [Janitor](Janitor.md), [Clown](Clown.md), [Mime](Mime.md), [Curator](Curator.md), [Lawyer](Lawyer.md), [Chaplain](Chaplain.md), [Assistant](Assistant.md) |
+| Service     | [Bartender](Bartender.md), [Cook](Cook.md), [Janitor](Janitor.md), [Clown](Clown.md), [Mime](Mime.md), [Curator](Curator.md), [Lawyer](Lawyer.md), [Chaplain](Chaplain.md), [Assistant](Assistant.md), [Psychologist](Psychologist.md) |
 | Synthetic   | [Station AI](Station-AI.md)                                  |
-| Antagonist  | [Revolutionary](Cargonia.md), [Nuclear operative](Nuclear-Emergency.md), [Traitor](Traitor.md), [Blob](Blob.md),[Wizard](Wizard.md),[Fugitive](Fugitive.md) |
-| Other       | [Centcom Officer](Central-Command-Officer.md), [Death Squad](Death-Squad.md), [Emergency Response Team](Emergency-Response-Team.md) |
+| Ghost Roles | [Ancient Engineer,](Ancient-Engineer.md) [Ash Walker,](AshWalker.md) [Fugitive](Fugitive.md) |
+| Antagonist  | [Revolutionary](Cargonia.md), [Nuclear operative](Nuclear-Emergency.md), [Traitor](Traitor.md), [Blob](Blob.md), [Wizard](Wizard.md), |
+| Centcom     | [Centcom Officer](Central-Command-Officer.md), [Death Squad](Death-Squad.md), [Emergency Response Team,](Emergency-Response-Team.md) [Redshield Officer](Redshield-Officer.md) |


### PR DESCRIPTION

- fixed a few typos in Syndicate-Items.md and added a strategy description to the stalker.
- fixed the incorrect page name for the Ash Walker role and improved their description.
- removed maintenance access that was listed for the Medical Doctor (it was removed from the role when the Paramedic was added)
- added a couple missing accesses from the paramed page
- renamed the Psychologist file name and gave them role stats and a brief description.
- removed the broken table from the Botanist's page and added a small blurb about traitoring as one.
- Added an overview to the Station AI page, as well as a description of the AI Satellite and Binary chat
- updated the Roles nav bar with several missing roles.

Overall, nothing too major. Just general clean up. Less pages have blank sections in them, so oo-rah or whatever.