### PR TITLE
add Anatomy of a Station page

### DIFF
--- a/docs/Maps/Anatomy of a space station.md
+++ b/docs/Maps/Anatomy of a space station.md
@@ -1,0 +1,170 @@
+# Anatomy of a Space Station (WIP)
+Space stations come in all sorts of shapes and sizes. Some, like [Fallstation](fallstation.md), are small and petite, designed to support focused gameplay around 20 players. Others, like [Boxstation,](boxstation.md) are massive operations, with numerous rooms and a maze of maintenance tunnels, and an intended player count of 50 or more players.
+
+All the same, NanoTrasen's research stations are all designed to certain standards to simplify logistics and to ensure minimum decent standards of living, safety, and security. So, many of the different rooms and departments you will find on one map, as well as the supply stocks in those rooms, will also be present on other maps in one way or another.
+
+## General
+
+### Arrivals Dock
+
+All crew members that have just been shipped from Central Command arrive at the station in the Arrival Shuttle.
+
+### Primary Tool Storage
+
+Primary Tool Storage is exactly what it says on the tin, a storage room where construction tools and supplies are stored. A great variety of goodies are available here, so naturally it's one of the first places hit by [The Tide](Assistant.md) at the start of a round. It is the only public source of insulated gloves other than lucky loot drops in maintenance.
+
+### Evacuation Dock
+
+### Security Posts
+
+Some departments and hallways ma have Security Posts attached to them. Security Posts provide Security with means of observing and entering other departments.
+
+### Emergency Storage
+
+Usually accessed through a windowless airlock with green stripes. These rooms are publicly accessible and provide emergency supplies to help mitigate the dangers of a breach, a fire, or if some lightbulbs need changing. Emergency Storage rooms almost always have a maintenance hatch at the back of the room.
+
+
+
+## Command
+
+### Bridge
+
+### Captain's Quarters
+
+### Conference Room
+
+### HoP's Office
+
+### Vault
+
+### EVA
+
+### Gateway
+
+### AI Satellite
+
+
+
+## Service
+
+### Bar
+
+### Chapel
+
+### Dormitory
+
+### Kitchen
+
+### Library
+
+
+
+## Medical
+
+### Med Bay
+
+### Pharmacy
+
+### CMO's Office
+
+### Medical Storage
+
+### Morgue
+
+### Operating Theatre
+
+### Virology
+
+
+
+## Cargo
+
+### Cargo Bay
+
+This is where Cargo's business is conducted. Supply crates are ordered on the supply console located in this room and shipped in via shuttle. Conveyor belts and the extra space help expedite the process for [Cargo Techs](cargo-technician.md). Typically attached is the Crate Warehouse, a dirty old room where crates are stored. 
+
+Sometimes either located in this room or in a small adjacent room is the Cargo Office, which is the home of Cargo's autolathe and the place where crew can come and request purchases.
+
+### Quartermaster's Office
+
+The [QM's](quartermaster.md) home. Typically has a redundant supply console and the QM's mining hardsuit, as well as loads of paper and paper-based products.
+
+### Mining Bay
+
+[Shaft miners](Shaft-Miner.md) start their shift here, and it's also the only direct access to Lavaland. It contains a few equipment lockers, the Ore Redemption Machine, and the mining equipment vendor.
+
+
+
+## Security
+
+### Brig
+
+### Armory
+
+### Courtroom
+
+### Detective's Office
+
+### HoS's Office
+
+### Law Office
+
+### Evidence Room
+
+
+
+## Engineering
+
+### Engine Bay
+
+### Atmospherics
+
+### CE's Office
+
+### Electricals
+
+### Technical Storage
+
+### Gravity Room
+
+### Telecommunications
+
+
+
+## Research
+
+currently under construction. come back later.
+
+### Research Division
+
+### Genetics
+
+### R&D Lab
+
+### Robotics Bay
+
+### Toxins Lab
+
+### Xenobiology Lab
+
+### RD's Office
+
+
+
+## Maintenance
+
+All of the tunnels outside of the main halls are probably maintenance. This is the most common access on the station, though not completely ubiquitous, and the area is marked by its proximity to every other area, its poor lighting, and its exposed pipes. Maintenance is typical filled with a smattering of random items and trash. If you bother to look, occasionally you might find something rather useful.
+
+[Fugitives](fugitive.md) and a number of [miscellaneous](Mobs.md) creatures spawn here.
+
+### Custodial Closet
+
+The [Janitor's](Janitor.md) home. A janitor's locker and vendor are located here along with loose janitorial supplies.
+
+### Waste Disposal
+
+Waste Disposal is a special maintenance area. It is typically worked by [Cargo Technicians](cargo-technician.md) or the [Janitor](janitor.md). This is the final destination of all those items that get disposed of properly in the Delivery Office in Cargo. The lever controls the conveyor system while the two buttons on the left wall control the blast door and mass driver.
+
+The [AI](Station-AI.md) has no cameras in this area, making it the perfect location to perform [crimes](traitor.md).
+
+On some maps, Waste Disposal is located *outside* the station's boundaries, meaning if you jump into a disposal bin without a means of space walking, you might trap yourself.


### PR DESCRIPTION

This new page is to mirror the station anatomy pages available on the /tg/ wiki and others. It's to give general information about the different rooms and departments of a station. Ideal in the future this will be a more interactive page (and would ideal be fully filled out, too) but, this is a start.