### PR TITLE
improved antag pages and more role page references

### DIFF
--- a/docs/Guides/Engineering guides/Construction.md
+++ b/docs/Guides/Engineering guides/Construction.md
@@ -1,8 +1,8 @@
 # Construction
 
-Construction and deconstruction are essential tools for Engineers and Traitors alike, it is, however, decently intuitive. For most of the buildings, the only thing you must do is activate the required materials in your hand (via pressing z or just clicking them).
+Construction and deconstruction are essential tools for [Engineers](engineer.md) and [Traitors](traitor.md) alike. For most of the buildings, the only thing you must do is activate the required materials in your hand (via pressing z or just clicking them).
 
-The main feature of space station 13 is for any item in the game to be either ordered from the quartermaster, or built with materials. As this game is a work-in-progress, we're not quite there yet, here are some things you can build and deconstruct, though.
+A main feature of Unitystation is that almost any item in the game can be either ordered from the [quartermaster](quartermaster.md), or built with materials. As this game is a work-in-progress, we're not quite there yet. But here are some things you can build and deconstruct, though.
 
 ## Cloth ![Cloth](stack_objects_sheet-cloth.png)
 

--- a/docs/Items/Syndicate Items.md
+++ b/docs/Items/Syndicate Items.md
@@ -20,27 +20,31 @@ This is a comprehensive list of all items that [Traitors](Traitor.md) and [Nucle
 |  Syndicate Minibomb  | stronger blast than a grenade, but hits a smaller total area. The detonation time after being activated is 5 seconds. | 6TC |
 |  C4  | A bomb that can be attached to walls, objects, and people while on harm intent. It can be configured to detonate on a timer (minimum time 10 seconds), or can be paired with a remote signaller to be remotely triggered. To pair it, simply click the remote signaller on the C4 brick and they are paired. | 1TC |
 |  X4  | C4 but more explosive. | 4TC |
-|  Pizza Bomb | A bomb concealed in a pizza box. | 10TC |
+|  Pizza Bomb | A bomb concealed in a pizza box. sneaky, and yet, so obvious. | 10TC |
 |  Powersink | A bomb that charges up from a wire under it while anchored with a screwdriver. How fast and how strong it exploads depends on how much power is flowing under it and will cause a black out as long as a nearby department battery is offline. | 15TC |
 |  Syndicate Bomb | A huge bulky bomb that is twice as strong as a single X4. When ordered it will give the user a device that will summon the bomb and a remote upon activating directly at where the user is standing. | 20TC |
 | <font color="red">**STEALTHY WEAPONS**</font> | Easily concealed and hard to trace weapons. |  |
 |  Energy Dagger | A smaller and weaker esword disguised as a pen, can be placed anywhere you can fit a pen, like your PDA. | 2TC |
-|  Miniature Energy Crossbow | An (expensive) self charging and easily hideable pocket crossbow that stuns and poisons those it hits. basically a self charging concealable tazer. When fired, it does not leave a message in the chat that would give away your identity | 10TC |
+|  Miniature Energy Crossbow | An (expensive) self charging and easily hideable pocket crossbow that stuns and poisons those it hits. Basically a discrete poison tazer. When fired, it does not leave a message in the chat that would give away your identity. This weapon desperately needs to be paired with another, as the damage and rate of fire are insufficient to kill anyone quickly, but the stun and quiet firing are immensely helpful in an ambush. | 10TC |
 |  Syndicate Holster | A holster for storing all the guns you buy. Cannot currently be disguised, so it's not a very effective stealth tool at the moment. | 1TC |
 |  Suppressor | Reduces the volume of guns with threaded barrels and it does not leave chat messages saying who fired it. Current weapons that can be silenced are Makarovs and Stalker SMGs. | 3TC |
 | <font color="red">**SUITS**</font> | Various suits, typically of the spaceworthy variety. |  |
-|  Syndicate Spacesuit | A spacesuit that can be used similarly to other softsuits on the station. Despite being a softsuit, it is actually very protective, providing better stats than standard security officer armor. while it's main utility is for Traitors, don't forget that as a nuclear operative, this is a good option if you plan to sneak aboard the station and adopt a disguise as it is small enough to fit inside a backpack, allowing you to keep it for when you need to go loud or escape the station. | 4TC |
+|  Syndicate Spacesuit | A spacesuit that can be used similarly to other softsuits on the station. Despite being a softsuit, it is actually very protective, providing slightly better stats than standard security officer armor. while it's main utility is for Traitors, don't forget that as a nuclear operative, this is a good option if you plan to sneak aboard the station and adopt a disguise as it is small enough to fit inside a backpack, allowing you to keep it for when you need to go loud or escape the station. | 6TC |
 |  Syndicate Hardsuit | The same armoured blood-red hardsuit used by nuclear operatives. Very distinct looking, very robust. | 8TC |
 | <font color="red">**MISC. GADGETS**</font> | Gadgets that don't fit in with others |  |
 |  Chest Rig | Acts as an 8 slot belt that can store guns, ammo, grenades, and all manner of other devices. Very cheap, very flexible storage, but also can't be hidden when worn. | 1TC |
 |  Cryptographic Sequencer | Otherwise known as the Emag. It causes doors to open, and certain other machinery to malfunction. Generally, the effects of the Emag are permanent unless someone repairs the affected machines; For example, doors will stay permanently open until repaired. The effects of the Emag are powerful, but it does mean that you leave an obvious trail to follow if you are being pursued. The Emag has 5 regenerating charges, and you can see roughly how many you have left on the card's sprite. It regenerates one charge after 30 seconds. | 6TC |
 |  Surgical Equipment Bundle | Comes with all the tools for surgery in a conspicuous, red and black duffel bag. | 3TC |
+| Combat Med Kit | A slightly larger than normal military first aid kit that comes with the basic medical consumables. | 4TC |
 |  Full Syndicate Toolbox | A mechanical toolbox full of tools, but eviler. Small serrations on the exterior of the toolbox also give it slightly increased melee damage. | 1TC |
 |  Syndicate Soap | Soap, but red, menacing. good for cleaning up any blood from your assassinations. | 1TC |
 | <font color="red">**(POINTLESS) BADASSERY**</font> | Useless fun, or with very niche or RP oriented uses. |  |
 |  Syndicate Balloon | A baloon to show everyone you are with the syndicate, great for getting yourself shot. | 20TC |
 |  Briefcase Full of Cash | A Briefcase full of cash, need I say more? | 1TC |
 |  Syndicate Smokes | A pack of syndicate smokes, operate in style! | 2TC |
+| Clown Costume | everything you need to dress yourself as a clown, with a crayon box and a disguised syndicate headset | 4TC |
+| Greytide Costume | provides more than just an assistant's uniform and disguised headset, it also comes with insulated gloves and an old gas mask | 4TC |
+| Centcom Officer Costume | comes with a centcom officer's uniform and a disguised syndicate headset, but no revolver, so it's a bit risky if other people know to look for that. | 20TC |
 | <font color="red">**BUNDLES**</font> |  |  |
 |  Raw Telecrystals | The currency for transactions made with the syndicate. Add them to a PDA by clicking on it with them in hand. If you kill another traitor, check to see if their uplink is still unlocked on their PDA and take their telecrystals for yourself. | 1, 5, 10, or 20 TC |
 
@@ -93,9 +97,9 @@ Some items are only available to [Nuclear Operatives.](Nuclear-Operative.md)
 | <font color="red">**BUNDLES**</font>             | Think of the savings!                                        |         |
 | Bioterror bundle                                 | Currently not worth getting as chemistry is underdeveloped. 12 TC saved. | 30TC    |
 | Bulldozer bundle                                 | Comes with a Bulldozer shotgun, a 12g *stun* slug drum and buckshot drum. Stun slugs are a useful way to get stuns if you need to take someone alive for one reason or another. Saves you 3TC | 13TC    |
-| Stalker bundle                                   | A duffel bag that comes with a stalker with a supressor and two extra magazines. | 14TC    |
+| Stalker bundle                                   | A duffel bag that comes with a stalker with a supressor and an AP magazine and an Incendiary magazine. It saves you 7TC, but since nukies already start with a stalker, really, it's -3TC. This mainly has utility under the very specific circumstances of when you need to arm another person for whatever reason. | 15TC    |
 | Sniper bundle                                    | A briefcase that comes with a Migraine, two spare magazines, and a worn out suit and tie. Saves you 6TC | 20TC    |
-| Spetznas Pyro Bundle                             | Currently not worth getting as it doesn't come with all items it is supposed to. | 30TC    |
+| Spetznas Pyro Bundle                             | comes with an elite syndicate hardsuit, a stechkin pistol, 2 magazines of stechkin incendiary ammo, a minibomb, and vodka. Not very effective, but definitely fun. | 30TC    |
 
 
 

--- a/docs/Roles/Antagonist roles/Nuclear-Operative.md
+++ b/docs/Roles/Antagonist roles/Nuclear-Operative.md
@@ -15,13 +15,15 @@ The shuttle contains the nuke, the very thing you need to complete your mission,
 
 ### Your gear and you
 
+##### [To see what's available to buy from the Uplink, go here.](Syndicate Items.md)
+
 The stock nukie gear consists of your uniform, night vision goggles, hardsuit helm, a syndicate mask, your signature red hardsuit, a pair of red magboots or black jackboots, your headset, gloves, an oxygen tank, a stalker SMG, a PDA which has your telecrystal uplink, and your trusty stetchkin pistol. 
 
-Your night vision does exactly what youd expect, letting you see in dark areas. The hardsuit helm and torso pieces make you immune to the cold and pressure, while offering very decent protection against weapons and explosives. You are not invincible in these however, and getting shot will still hurt. The headset doesn't let you hear the crew, but it does give you access to your own syndicate channel. 
+Your night vision does exactly what you'd expect, letting you see in dark areas. The hardsuit helm and torso pieces make you immune to the cold and pressure, while offering very decent protection against weapons and explosives. You are not invincible in these however, and getting shot will still hurt. The headset doesn't let you hear the crew, but it does give you access to your own syndicate channel. 
 
 The Stalker will be your main offensive weapon unless you choose to [buy something else](Syndicate Items.md) to replace it. Be sure to bring extra ammo for it, as it burns through magazines rapidly. 
 
-The stetchkin is a small but scrappy fallback pistol. Use it if you've run out of other ammo or wish to conserve it. One of the best uses for the pistol, however, is getting someone out of the way, as one or two shots will usually send any unarmed crew member running. Be creative with your gear and strategize before hand, its how you'll win! speaking of which:
+The stetchkin is a small but scrappy fallback pistol. Use it if you've run out of other ammo or wish to conserve it. One of the best uses for the pistol, however, is getting someone out of the way, as one or two shots will usually send any unarmed crew member running. Be creative with your gear and strategize before hand, its how you'll win! speaking of which...
 
 ### How to do your job
 

--- a/docs/Roles/Antagonist roles/Traitor.md
+++ b/docs/Roles/Antagonist roles/Traitor.md
@@ -27,9 +27,7 @@ At the start of your round as traitor, you will be given a *case-sensitive* pass
 
 Acquiring more TC is functionally improbable, as it requires you to kill another traitor who has their own uplink *still unlocked* and *they haven't spent it all.*
 
-###### To see what's available to buy and some general footnotes about the items, go [here.](Syndicate Items.md)
-
-
+#####  [To see what's available to buy from the Uplink, go here.](Syndicate Items.md)
 
 ## [Theft](High-Risk-Items.md) objectives
 
@@ -37,7 +35,7 @@ Often one or both of your objectives requires you to steal something. How hard t
 
 Theft objectives will often require you to break into secure areas or to steal the items directly off of other players. Sometimes it will be shockingly easy, easier than taking candy from a baby. Other times it will be [so impossible](So-close-to-impossible-that-it-might-as-well-not-even-exist.md) that you should probably take the L and try to have fun getting up to shenanigans with your exclusive traitor items. It all depends on what state the station is in and how many players are alive. Still, woe betide anyone who gets the objective `steal the Justitia.`
 
-###### to see a complete list of steal objects you can expect to get, take a look at the [High Risk Items](High-Risk-Items.md) page.
+##### [to see a complete list of steal objects you can expect to get, take a look at the High Risk Items page.](High-Risk-Items.md)
 
 ## Murder objectives
 

--- a/docs/Roles/Antagonist roles/Wizard.md
+++ b/docs/Roles/Antagonist roles/Wizard.md
@@ -3,17 +3,16 @@ Role type:  <font color= "#711e25">Antagonist</font>. Access levels: <font color
 
 Space Wizards are a unique antagonist who has access to magical powers that defy scientific principles. Most are part of the Space Wizard Federation, a mysterious organization that is at war with NanoTrasen. The source of the wizard's power is their spellbook, which they consult to master a variety of spells to cast to cause chaos and devastation.
 
-As the wizard, you will be given quite a few objectives (typically 4) to complete that will require you to steal high-risk items and assassinate crew members. Even as an almighty wizard, master of time and space, you are ultimately just as squishy and vulnerable as any other person. So, if you are to complete your objectives and survive to the end of the round, you will still have to high degree of cleverness to get the job done.
+As the wizard, you will be given quite a few objectives (typically 4) to complete that will require you to steal high-risk items and assassinate crew members. Even as an almighty wizard, master of time and space, you are ultimately just as squishy and vulnerable as any other person. So, if you are to complete your objectives and survive to the end of the round, you will still have to demonstrate a high degree of cleverness to get the job done.
 
-
-**Understand that the Wizard is a work-in-progress antagonist, and does not have all of their abilties in game yet.**
+**Understand that the Wizard is a work-in-progress antagonist, and does not have all of their abilties in game yet. Still, there's plenty to have fun with; enjoy your superiority over the station.**
 
 
 ## Wizarding 101
 
 You can use the mirror to change your name to whatever you want. 
 
-_coming soon_
+You can also get different colored wizard robes from the Magivend vending machine to customize your appearance.
 
 ## Spells
 
@@ -21,21 +20,23 @@ _coming soon_
 | -------------------- | ---- | -------- | ----------- | ---------- |
 | **Offensive Spells** |      |          | Used to kill or otherwise injure others             |            |
 | Fireball | 2 spell points | 6 seconds | Summons an explosive fireball. When thrown, it will explode upon hitting a target, dealing a high amount of fire damage. Maximum range 8 tiles |ONI'SOMA! |
-| Lesser Summon Guns | 3 spell points | 75 seconds | Summon a Surplus rifle in hand. Several others pop out of worm holes around the wizard |  |
-| Lighting Bolt | 1 spell point | 10 seconds | Summon lighting from your hands. | P'WAH, UNLIMITED P'WAH | 
-| **Defensive** |        |         | Used to protect yourself | 
-| Forcewall | 1 spell point | 10 seconds | Summon a 3x1 wall that you can walk through. | TARCOL MINTI ZHER! | 
-| Rockdrop | 1 spell point | 45 seconds | Drop rocks on your enemies | BALDERDASH! |
-| Mastercrafted Armor Set | 2 spell points | N/A | Delivered via a drop pod landing on the wizard's tile. **Move out of the way or you will be crushed.** A magic-encrusted spacesuit. It slows you down a bit, but it provides good armor. | | | 
+| Lesser Summon Guns | 3 spell points | 75 seconds | Summon a Surplus rifle in hand. Several other rifles pop out of worm holes around the wizard. |  |
+| Lighting Bolt | 1 spell point | 10 seconds | Summon lighting from your hands. Generally low damage, but the potential increases when you fire it into groups, as the lightning will arc from your target to others nearby. A good budget damage option. | P'WAH, UNLIMITED P'WAH |
+| Spell Blade | 2 spell points | N/A | Delivered via a drop pod landing on the wizard's tile. **Move out of the way or you will be crushed.** A laser-flinging sword; decently robust. The projectiles it fire are armor piercing and recharge quickly, giving you a decent solution for protracted gunfights as a wizard. |  |
+| **Defensive** |        |         | Used to protect yourself ||
+| Forcewall | 1 spell point | 10 seconds | Summon a 3x1 wall that you can walk through. | TARCOL MINTI ZHER! |
+| Rockdrop | 1 spell point | 45 seconds | Drop rocks on your enemies. The tile you click will get hit with a movement-blocking rock while smaller passable rocks will rain down around it randomly. Does low damage, but the large rock does more. Can be used in creative ways, such as to block off areas or to provide yourself cover from projectiles. The rocks can be mined away with a pickaxe. | BALDERDASH! |
+| Mastercrafted Armor Set | 2 spell points | N/A | Delivered via a drop pod landing on the wizard's tile. **Move out of the way or you will be crushed.** A magic-encrusted spacesuit. It slows you down a bit, but it provides good armor. | |
+| Stunning Bolt | 2 spell points | 1.5 seconds | It lets you fire a stunning electrode exactly like a taser, though with a longer maximum range. It's quick cooldown allows you to spam it annoyingly fast. | LIGHTNINGBOLT!! |
 | **Mobility Spells** |  |  |Allow for more rapid movement, it is STRONGLY advised to take at least one  |  |
 | Teleport | 2 spell points | 60 seconds | Instantly teleport to a chosen location anywhere on your Z-level. | SCYAR NILA! |
 | Blink | 2 spell points | 2 seconds | _randomly_ teleport a medium distance. It will _try_ to not teleport the wizard into space, but it will sometimes, so be prepared. | |
-| **Assistance** |     |    | Spells that help in indirect ways | 
-| Instant Summons | 1 spell point | 10 seconds | Teleports an item you selected to yourself, along with its container. | GAR YOK | 
-| Contract of Apprencticeship | 2 spell points |  | Gives a ghost the opportunity to join you as an apprentice. | 
-| **Rituals** |    |    | Really messes with security. | 
-| Summon guns | 2 spell points |  | Arms everyone on the station. | |
-| Summon magic | 2 spell points | | Gives small magical books to everyone on the station. | | 
+| **Assistance** |     |    | Spells that help in indirect ways ||
+| Instant Summons | 1 spell point | 10 seconds | Teleports an item you selected to yourself, along with its container. | GAR YOK |
+| Contract of Apprencticeship | 2 spell points | N/A | Gives a ghost the opportunity to join you as an apprentice. ||
+| **Rituals** |    |    | Really messes with security. ||
+| Summon guns | 2 spell points |  | Big version of Lesser Summon Guns. Arms everyone on the station with a gun. | |
+| Summon magic | 2 spell points | | Gives magical books to everyone on the station, letting them each learn a magical spell. | |
 
 
 ## The Friendly Wizard

--- a/docs/Roles/Cargo roles/Cargo-Technician.md
+++ b/docs/Roles/Cargo roles/Cargo-Technician.md
@@ -15,21 +15,20 @@
 
 You are the delivery boy on the station. Your job is pretty simple: Sit at the cargo desk, take the cargo orders of people that need some item or another, and help the [Quartermaster](Quartermaster.md) in his goal to become the richest department on the station. You make sure every department has what they need to operate and that no one sneaks in and orders twenty machine gun crates without you knowing.
 
-Cargo Technician is perhaps the best role to play to learn the game after you get the basics of movement down from [Assisting](Assistant.md) Your responsibilities are nearly zero. The only skills you need to know are how to move freight, process forms, and how the cargo console works. Delivery trips are also an excellent way to learn the layout of the station and how everything fits together. You will also discover the general needs and activities of the other departments based on what they order from you. It's a pretty cash money job.
+Cargo Technician is perhaps the best role to play to learn the game after you get the basics of movement down from playing [Assistant](Assistant.md). Your responsibilities are nearly zero. The only skills you need to know are how to move freight, process forms, and how the cargo console works. Delivery trips are also an excellent way to learn the layout of the station and how everything fits together. You will also discover the general needs and activities of the other departments based on what they order from you. It's a pretty cash money job.
 
 ### Engineering come pick up your metal plates crate now or we will claim it for ourselves
 
 Let's start with a big note on 'safety:'
 
-* Do not trap yourself or others between piles of boxes or by closing the docking shutters on people.
+* Do not trap yourself or others between piles of boxes or by closing the docking shutters on people. It's annoying and rude. If you do get pinned in by boxes, you can drag yourself onto crates (while on help intent) to climb on top.
 * When you send the shuttle, make sure that the docking shutters are closed so you don't vent the cargo room out into space when the shuttle leaves.
 * Keep any conveyor belts off when you are not using them.
-* 'always** check to see if someone is in the cargo shuttle before you send it off. Anyone inside when it leaves will be instantly killed and ''cannot be revived by the admins. This will get you a temporary ban most of the time even if you are an [Antagonist](Traitor.md)
-* If you are ever launched to your doom in the cargo shuttle, you have about 3-5 seconds to jump out the airlock in which someone might be able to find your cold dead corpse. It's better than nothing.
+* always check to see if someone is in the cargo shuttle before you send it off.
 
 Now that's covered...
 
-Your department head is the Quartermaster. Typically, they will be the one deciding what is purchased on the cargo console, so you will likely get stuck with paper duty when not dragging boxes on and off the shuttle. At the front desk, take paper and pens and prepare a couple General Request forms. You can come up with something on your own or just copy this template and paste it onto each paper:
+Your department head is the [Quartermaster](quartermaster.md). Typically, they will be the one deciding what is purchased on the cargo console, so you will likely get stuck with paper duty when not dragging boxes on and off the shuttle. At the front desk, take paper and pens and prepare a couple General Request forms. You can come up with something on your own or just copy this template and paste it onto each paper:
 
 Request Form:
 
@@ -48,7 +47,7 @@ Sometimes people may ask you to order something sketchy; at that point you eithe
 
 ### Revenge of the delivery boy ( [traitor](traitor.md) Cargo Tech)
 
-Being a [traitor](traitor.md) as a Cargo Tech is pretty nice. You don't have any significant responsibilities and low attention is paid to you by most people except the [QM](Quartermaster.md). Just do the bare minimum required of you while you hatch your scheme to fulfill your objectives. A prized possession of the Cargo Tech is the Cryptographic Sequencer. It allows you to bypass the locks on many devices, most notable to the Cargo Tech, the secure crates purchasable at the Cargo Console. While it can be difficult to ensure the QM doesn't notice it when he signs off on the order, if you do manage it, the Emag will allow for an easy supply of firepower. Still, it's risky.
+Being a [traitor](traitor.md) as a Cargo Tech is pretty nice. You don't have any significant responsibilities and low attention is paid to you by most people except the [QM](Quartermaster.md). Just do the bare minimum required of you while you hatch your scheme to fulfill your objectives. A prized possession of the Cargo Tech is the Cryptographic Sequencer (aka, Emag). It allows you to bypass the locks on many devices, most notable to the Cargo Tech, the secure crates purchasable at the Cargo Console. While it can be difficult to ensure the QM doesn't notice it when he signs off on the order, if you do manage it, the Emag will allow for an easy supply of firepower. Still, it's risky.
 
 Whether you have an Emag or not, there's loads of purchasable items on the cargo console that won't immediately elicit suspicion. Peruse the options and you should be able to find some items that will help you develop a plan of action.
 

--- a/docs/Roles/Cargo roles/Quartermaster.md
+++ b/docs/Roles/Cargo roles/Quartermaster.md
@@ -41,26 +41,39 @@ When the [miners](Shaft-Miner.md) actually [survive](So-close-to-impossible-that
 
 | Item Name                                    | Price        | Contents                                                     | Crate Reclamation Payout (refund%) |
 | -------------------------------------------- | ------------ | ------------------------------------------------------------ | ---------------------------------- |
-| Kitchen                                      |              |                                                              |                                    |
+| **Armory** |  |  |  |
+| Shotguns Crate                               | 5000         | 3 combat shotguns (loaded)                                   | 750 (15%)                          |
+| R550c PDW SMGs        | 5000         | 3 machine-guns (loaded)                                      | 750 (15%)                          |
+| E-guns Crate                 | 4500         | 3 laser guns                                                 | 750 (16%)                          |
+| Riot Suppression Bundle |  |  |  |
+| Riot Suit |  |  |  |
+| Riot Shields |  |  |  |
+| SWAT Gear bundle |  |  |  |
+| electronic firing pins |  |  |  |
+| **Kitchen**                                  |              |                                                              |                                    |
 | Beet Crate                                   | 700          | 3 beers (really?)                                            | 500 (71%)                          |
 | Meat Kit Crate                               | 600          | 5 Meats, 1 Chef's Knife                                      | 500 (83%)                          |
-| Knife Kit Crate                              | 500          | 3 chef's knives                                              | 500 (100)%                         |
+| Knife Kit Crate                              | 500          | 3 chef's knives                                              | 500 (100%)                       |
 | Energy Crate                                 | 500          | 5 iced coffees                                               | 500 (100%)                         |
 | Better Eyes Crate                            | 600          | 5 cups of carrot(?) juice                                    | 500 (83%)                          |
 | **Security**                                 |              |                                                              |                                    |
 | [Handcuffs Crate](Security-Officer-Guide.md) | 900          | 5 handcuffs                                                  | 500 (55%)                          |
-| Batons Crate                                 | 1500         | 3 wooden batons                                              | 750 (50)                           |
-| Shotgun Crate                                | 5000         | 3 combat shotguns (loaded)                                   | 750 (15%)                          |
-| Machine-gun Crate                            | 5000         | 3 machine-guns (loaded)                                      | 750 (15%)                          |
-| Laser Gun Crate                              | 4500         | 3 laser guns                                                 | 750 (16%)                          |
-| Laser Pistol Crate                           | 4000         | 3 laser pistols                                              | 750 (18%)                          |
+| Stun Batons Crate                            | 1500         | 3 stun batons                                          | 750 (50)                           |
+| Laser guns Crate                     | 4000         | 3 laser pistols                                              | 750 (18%)                          |
+| Body Armor | 800 | 3 armor vests, 3 security helmets | 500 |
+| Bullet Proof Armor | 200 | 3 bullet proof vests, 3 bullet proof helmets | 500 |
+| Ammo Crate | 1600 | 3 WT550 magazines, 3 boxes of rubbershot, 3 specialist .38 speedloaders | 750 |
+| Security Clothing Bundle | 800 | clothing for all security jobs | 500 |
 | **Medical**                                  |              |                                                              |                                    |
-| First Aid Kit Crate                          | 800          | 3 First Aid Kits                                             | 500 (62%)                          |
-| Burn Kit Crate                               | 800          | 3 Burn Kits                                                  | 500 (62%)                          |
-| Body Bag Crate                               | 800          | 2 body bag boxes (14 body bags)                              | 500 (62%)                          |
-| Beaker Box Crate                             | 700          | 3 beaker boxes (21 beakers)                                  | 500 (71%)                          |
+| Medical Kits                  | 800          | 2 first aid kits, 2 burn kits                           | 500 (62%)                          |
+| Defibrilliators               | 800          | 2 defibrillators                                   | 500 (62%)                          |
+| Body Bags                              | 800          | 2 body bag boxes (14 body bags)                              | 500 (62%)                          |
+| Beaker Boxes                           | 700          | 3 beaker boxes (21 beakers)                                  | 500 (71%)                          |
+| Medical Peripherals | 700 | box of beakers, box of prescription glasses, box of latex gloves, 4 nitrile gloves, 2 health analyzers |  |
+| Medical bundle |  |  |  |
+| Surgical Supplies | 1200 | Roller bed, surgical duffel bag |  |
 | **Science**                                  |              |                                                              |                                    |
-| Chemistry Kit Crate                          | 800          | 1 bucket, 1 chemist's labcoat, 2 large beakers               | 500 (62%)                          |
+| Chemistry Kit                          | 800          | 2 boxes of beakers, 2 large beakers, 1 chemist's labcoat, | 500 (62%)                          |
 | **Engineering**                              |              |                                                              |                                    |
 | Tool Crate                                   | 700          | 2 mechanical toolboxes, 2 tool belts                         | 500 (71%)                          |
 | Low Voltage Cable Crate                      | 800          | 3x30 low power cable bundles                                 | 500 (62%)                          |
@@ -75,27 +88,30 @@ When the [miners](Shaft-Miner.md) actually [survive](So-close-to-impossible-that
 | Storage Crate                                | 600          | just an empty crate. Get the energy crate for cheaper. And it comes with free coffee! | 500 (83%)                          |
 | Cleaning Supplies Crate                      | 700          | 1 bucket, 1 mop, 1 trashbag, 1 space cleaner bottle          | 500 (71%)                          |
 | Replacement Lights Crate                     | 1000         | 3 boxes of lights (21 lightbulbs, 42 light tubes)            | 500 (50%)                          |
-| Wet Floor Signs Crate                        | 800          | 10 blank IDs                                                 | 500 (62%)                          |
-| ID Crate                                     | 550          | 10 blank IDs                                                 | 500 (90%)                          |
+| ID Crate                                     | 750       | 2 boxes of spare IDs                           | 500 (90%)                          |
+| Janitorial Supplies | 700 | 2 buckets, box of mousetraps, mop, 2 spray bottles of space cleaner, 2 soap bars, trash bag, 3 wet floor signs. | 500 |
+| Exotic carpeting |  | comes with loads of decorative carpets | 500 |
 | **Botany**                                   |              |                                                              |                                    |
 | Hydroponics Crate                            | 800          | 1 seed pack each: apples, bananas, berries, cherries, chilis, grapes, grass, lemons, limes, sunflowers | 750 (93%)                          |
-| **Mining**                                   |              |                                                              |                                    |
+| **Mining and Cargo**                         |              |                                                              |                                    |
 | Mining Tools Crate                           | 600          | 2 shovels, 2 picks, 2 lanterns, 2 PKAs                       | 500 (83%)                          |
-| Plasma Cutter Crate                          | 600          | 1 Plasma Cutter                                              | 500                                |
-| Advanced Plasma Cutter Crate                 | 600          | 1 Advanced Plasma Cutter                                     | 500                                |
+| Plasma Cutter Crate                          | 3000         | 1 Plasma Cutter                                              | 500                                |
+| Advanced Plasma Cutter Crate                 | 6000         | 1 Advanced Plasma Cutter                                     | 500                                |
+| Shaft Miner Starter Kit | 800 | Mining Conscription Duffel bag, mining satchel, PKA | 500 |
+| Cargo Tech Starter Kit | 750 | Cargo Tech clothing, export scanner, space beer (ayy!) | 500 |
 | **Emergency**                                |              |                                                              |                                    |
 | EVA Crate                                    | 800          | 1 mining hardsuit set, 1 large oxygen tank and mask          | 500 (62%)                          |
 | Internals Crate                              | 1000         | 3 oxygen masks, 3 large oxygen tanks, 3 personal oxygen tanks | 500 (50%)                          |
 | Firefighting Crate                           | 1000         | 2 flashlights, 2 fire extinguishers, 2 large oxygen tanks and masks | 500 (50%)                          |
 | Radiation Protection Crate                   | 800          | 2 radiation suit sets, 2 Geiger counters, 1 large oxygen tank and mask | 500 (62%)                          |
 | **Materials**                                |              |                                                              |                                    |
-| Cardboard sheets Crate                       | 1000         | 50 cardboard sheets                                          | 750                                |
-| Metal Crate                                  | 1500         | 50 metal                                                     | 500                                |
-| Glass Crate                                  | 2000         | 50 glass                                                     | 500                                |
-| Solid Plasma Crate                           | 3000         | 4 solid plasma                                               | 750                                |
-| Half Plasteel Crate                          | 7500         | 20 Plasteel                                                  | 500                                |
-| Full Plasteel Crate                          | 16500        | 50 Plasteel                                                  | 500                                |
-| Wood Planks Crate                            | 2000         | 50 wood planks                                               | 500                                |
+| Cardboard sheets                       | 1000         | 50 cardboard sheets                                          | 750                                |
+| Glass                                  | 2000         | 50 glass                                                     | 500                                |
+| Metal                                  | 1500         | 50 metal                                                     | 500                                |
+| Solid Plasma                           | 3000         | 5 solid plasma                                               | 750                                |
+| 20 Plasteel                         | 7500         | 20 Plasteel                                                  | 500                                |
+| 50 Plasteel                        | 16500        | 50 Plasteel                                                  | 500                                |
+| Wood Planks                            | 2000         | 50 wood planks                                               | 500                                |
 | BZ Canister                                  | 8000         | 1 Canister                                               | N/A                                |
 | CO2 Canister                                 | 3000         | 1 Canister                                               | N/A                                |
 | N2 Canister                                  | 2000         | 1 Canister                                               | N/A                                |
@@ -106,16 +122,19 @@ When the [miners](Shaft-Miner.md) actually [survive](So-close-to-impossible-that
 | Fuel Tank                            | 800         | 1 Tank                                               | N/A                                |
 | Extra Capacity Water Tank                            | 1200         | 1 Tank                                               | N/A                                |
 | Water Tank                            | 600         | 1 Tank                                               | N/A                                |
-| Vending Resupply Crate                       | 1500         | 1 Vending Resupply pack (doesn't work, just eats credits like a real vending machine) | 500 (33%)                          |
+| Vending Resupply Crate                       | 1500         | 1 Vending Resupply pack | 500 (33%)                          |
 | **Miscellaneous**                            |              |                                                              |                                    |
-| Monkey Crate                                 | 550          | 6 banana peels                                               | 500 (90%)                          |
-| Robusting Crate                              | 1000         | 8 mechanical toolboxes                                       | 500 (50%)                          |
-| Uniform Sets                                 |              |                                                              |                                    |
-| There's a crate for every station job        | 600 ~ 100000 |                                                              | 500 to 750(???)                    |
+| Big Band Instuments        | 1000      | piano, trombone, glockenspiel                                | 500                                |
+| Bureaucracy crate            | 750          | hand labeler, labeler roll (x2), paper bin, four color pen (x3), pen (x3) | 500                       |
+| wrapping paper | 750          | wrapping paper (x250) | 500 |
+| festive wrapping paper | 750          | festive wrapping paper (x250) |  |
+| religious supplies | 1400         | flask of holy water (x2), bible (x2), follower hood (x2) |  |
+| funeral supplies | 1400         | burial garments, flowers | arrives in a coffin |
+| Uniform Sets (one for every station job)     | 600 ~ 100000 |                                                              |                                    |
 
 
 
-### The business of blood and money ([traitor](traitor.md)QM):
+### The business of blood and money ([traitor](traitor.md) QM):
 
 A [traitor](traitor.md) QM is one of the best times you can have in this game. Through the cargo console you have easy access to weapons, illicit materials, basically whatever you need. Just be mindful of an active [AI](station-AI.md) or a snooping [HoP](Head-of-Personnel.md).
 

--- a/docs/Roles/Centcom roles/Emergency-Response-Team.md
+++ b/docs/Roles/Centcom roles/Emergency-Response-Team.md
@@ -11,19 +11,19 @@ So, the station is fucked, but not fucked enough to warrant a [death squad](Deat
 
 
 ERT come in the following types. Commanders, who lead ERT teams, Security, who act as guards, Medical, who act as doctors, Engineers, who act more like emergency repairmen, and a variety of joke roles. Almost all ERT officers are armed with an energy carbine (or tactical variant) and a stun baton and all of them are equipped with heavily armored ERT hardsuits. You should expect any ERT squad members to be at least competent in their assigned role.
-### ERT Commander, Leading the A-team
+### Commander ER Agent, Leading the A-team
 
 
 ERT commanders are the most barebones squad member, equipped with nothing but their carbine, 2 batons, and a set of handcuffs. Their job, as the name implies, is to lead the ERT team on whatever objective they are given by [Centcom](Admin.md). To do this, they can make use of the unique Centcom channel to communicate plans, information, and orders to other members of the ERT team. If the chain of command is broken or [the station is in anarchy](Battle-royale.md), the commander of the response team may be forced to TEMPORARILY take charge in order to fill the power vacuum and allow a proper leader to be found peacefully.
-### ERT Security, Diet Deathsquad
+### Security ER Agent, Diet Deathsquad
 
 
 The ERT security officer acts as the spearpoint of any ERT team. They are armed with a tactical energy carbine, baton, taser, and two pairs of handcuffs, and sport a red and black hardsuit. They are typically sent  to apprehend [security](Security.md) or [heads](Head-of-Personnel.md) [of](Chief-Engineer.md) [staff](Captain.md) when the personnel onboard the station are unable or unwilling to do so. This typically is not a peaceful affair, and security ERT tend to kill more often then they apprehend, which is why they are often confused for being a [death squad](Death-Squad.md).
-### ERT Medic, Walking Medkits
+### Medic ER Agent, Walking Medkits
 
 
 The ERT medical officers are deployed to handle large scale medical emergencies, but sometimes are deployed not to save the crew, but to heal the ERT squad should they face especially heavy resistance. They wear a white marked hardsuit and are equipped with first aid kit and a medibelt. 
-### ERT Engineers, The Only Competent Engineers
+### Engineer ER Agent, The Only Competent Engineers
 
 ERT engineers are only typically sent when something onboard the station has, or is about to, blow up horribly. Their job is to fix the damage to the station or prevent further damage, and in this they act more like emergency repairmen than engineers. They are the type of ERT that will most often split from the squad, simply because while the other ERT are sent to deal with people, the engineer is sent to deal with walls and reactors, both of which tend not to have legs. Along with the usual gun and baton, they come with a tool belt, industrial welding tool, and a first aid kit.
 
@@ -31,11 +31,11 @@ ERT engineers are only typically sent when something onboard the station has, or
 
 Technically a separate team, the PRT's purpose is to respond to and handle paranormal and cultish threats to the station. PRTs are similarly equipped to ERTs, apart from their custom magically fortified hardsuits, and come in 2 varieties; the inquisitor and the knight. Besides the armor, and the standard carbine, cuffs, and baton, the only unique item the inquisitor carries is the obsidian rod, just like the like the [chaplain's](Chaplain.md).
 
-### Joke ERT
-
-There are also two types of joke ERT:
+### Janitor ER Agent
 
 Janitor ERT, sent to purify and cleanse the station of filth and grime. The Janitor comes with an advanced mop, an empty bucket, a box of lightbulbs, stun baton, trash bag of holding, belt full of space cleaner spray bottles, back up mop, one'' wet floor sign and notably **no** energy carbine.
+
+### Clown ER Agent
 
 Clown ERT, sent to bring joy and annoyance to the crew. The clown ERT does come with an energy carbine (ooph), as well as baton, cuffs, a bike horn, and a banana.
 

--- a/docs/Roles/Service roles/Botanist.md
+++ b/docs/Roles/Service roles/Botanist.md
@@ -22,7 +22,7 @@ If the vending machine ever runs out of seeds, put some of your produce in the s
 Even if many people think this job is more of a farm simulator rather than a true space station 13 role, the truth is that the biggest interaction the botanist has is with the [Cook](Cook.md), and it's a complicated one. Also, a plasma incident is bad for the crops, so you are not just watching the plants grow, you are protecting them from the raising chaos of the station while they slowly develop into a fully grown plant, not just waiting for them to be harvested. 
 
 
-At the moment, the amount of things the botanist can do is limited. Grow apples to supplement the hunger for meat and grow wheat so the [Cook](Cook.md) can blend it into flour for burgers. When civil station life [disintegrates](Battle-royale.md), grow bananas and lay a minefield of peels around your turf to dissuade attackers. If you're an [Antagonist](Antagonist.md), you should mass produce as many lemons as you can, destroying the plants after each harvest and planting new ones from your yield or simply using unstable mutagen with a non-help intent to get mass producible grenades. 
+At the moment, the amount of things the botanist can do is limited. Grow apples to supplement the hunger for meat and grow wheat so the [Cook](Cook.md) can blend it into flour for burgers. When civil station life [disintegrates](Battle-royale.md), grow bananas and lay a minefield of peels around your turf to dissuade attackers. If you're an [Antagonist](Antagonist.md), you should try to get your hands on some unstable mutagen to speed up the breeding process so you can acquire the *fun* plants like lemon-nades, gatfruit, and bluespace bananas.
 
 ### The [traitor](traitor.md) botanist
 


### PR DESCRIPTION
This PR:

- adds several links between pages, making it easier to get around.
- fixes some types.
- removes some really out of date references to old bugs in the cargo tech page.
- adds the latest items and spells added to the wizard and syndicate items pages.
- improves the visibility of the syndicate items and HRI page links in the traitor and nukie pages.